### PR TITLE
Porting zetasql patch from zetasql-fuzzing that allows zetasql to build with clang

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -127,7 +127,7 @@ http_archive(
     # - Give visibility to ZetaSQL's base library to reuse some utilities
     # - Allow implicit conversion of grpc::Status to zetasql_base::Status
     # - Patches for flex, m4, and icu to work on MacOS
-    patches = ["@com_google_cloud_spanner_emulator//build/bazel:zetasql.patch"],
+    patches = ["@com_google_cloud_spanner_emulator//build/bazel:zetasql.patch", "//patches:zetasql.patch"],
     sha256 = "3be4b149adeef3b30462e271879d0b9e4a0fd358b83452b47fde427ae9046871",
 )
 

--- a/patches/zetasql.patch
+++ b/patches/zetasql.patch
@@ -1,0 +1,38 @@
+--- bazel/BUILD
++++ bazel/BUILD
+@@ -37,6 +37,11 @@
+     binaries = [
+         "m4",
+     ],
++    configure_env_vars = {
++        "CFLAGS":"-fno-sanitize=address",
++        "CXXFLAGS":"-fno-sanitize=address",
++        "LDFLAGS": "-stdlib=libc++ -B lld -lc++ --rtlib=compiler-rt --unwindlib=libunwind -fno-sanitize=address",
++    },
+     configure_options = [
+         "--disable-nls",
+     ],
+@@ -58,6 +63,9 @@
+     configure_env_vars = {
+         "M4": "$$EXT_BUILD_DEPS$$/m4/bin/m4",
+         "CC_FOR_BUILD": "$$CC$$",
++        "CFLAGS":"-fno-sanitize=address",
++        "CXXFLAGS":"-fno-sanitize=address",
++        "LDFLAGS": "-stdlib=libc++ -B lld -lc++ --rtlib=compiler-rt --unwindlib=libunwind -fno-sanitize=address",
+     },
+     lib_source = "@bison//:all",
+     static_libraries = ["liby.a"],
+@@ -78,7 +86,12 @@
+     # This seems to be necessary (using tools_dep and weird path) because unlike
+     # bison, flex needs to invoke m4 during build (whereas bison needs it only
+     # during `configure`).
+-    configure_env_vars = {"M4": "$$EXT_BUILD_DEPS$$/m4/bin/m4"},
++    configure_env_vars = {
++       "M4": "$$EXT_BUILD_DEPS$$/m4/bin/m4",
++        "CFLAGS":"-fno-sanitize=address",
++        "CXXFLAGS":"-fno-sanitize=address",
++        "LDFLAGS": "-stdlib=libc++ -B lld -lc++ --rtlib=compiler-rt --unwindlib=libunwind -fno-sanitize=address",
++       },
+     lib_source = "@flex//:all",
+     deps = [":m4"],
+ )


### PR DESCRIPTION
This simply ports a patch from the zetasql-fuzzing that allows zetasql to build with Clang.  It basically specifies specific compiler flags for build-dependencies of zetasql.