### PR TITLE
Created structured fuzz test for Emulator's CREATE TABLE API

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,23 @@
+#
+# Copyright 2020
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+""" Additional bazel imports for zetasql """
+
+licenses(["notice"])  # Apache 2.0
+
+exports_files([
+    "LICENSE",
+])

--- a/BUILD
+++ b/BUILD
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-""" Additional bazel imports for zetasql """
-
 licenses(["notice"])  # Apache 2.0
 
 exports_files([

--- a/BUILD
+++ b/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright 2020
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -175,23 +175,12 @@ load("@com_github_googleapis_google_cloud_cpp_common//bazel:google_cloud_cpp_com
 google_cloud_cpp_common_deps()
 
 http_archive(
-    name = "bazel_skylib",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
-    ],
-    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
-)
-
-http_archive(
     name = "libprotobuf_mutator",
     build_file = '@com_google_cloud_spanner_emulator_fuzzing//:third_party/envoy/libprotobuf_mutator.BUILD',
     strip_prefix = "libprotobuf-mutator-master",
     urls = ["https://github.com/google/libprotobuf-mutator/archive/master.tar.gz"],
 )
 
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-bazel_skylib_workspace()
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 protobuf_deps()
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
 workspace(name = "com_google_cloud_spanner_emulator_fuzzing")
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 # Emulator and CPP API dependencies
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -183,7 +183,7 @@ http_archive(
 
 http_archive(
     name = "libprotobuf_mutator",
-    build_file = '//:third_party/envoy/libprotobuf_mutator.BUILD',
+    build_file = '//third_party/envoy/libprotobuf_mutator.BUILD',
     strip_prefix = "libprotobuf-mutator-master",
     urls = ["https://github.com/google/libprotobuf-mutator/archive/master.tar.gz"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -131,14 +131,15 @@ http_archive(
     sha256 = "35072a210111eb478d4cbc005496b4df026131127e2bf26a369d269b679a91ff",
 )
 
-# Protobuf
-if not native.existing_rule("com_google_protobuf"):
-    http_archive(
-        name = "com_google_protobuf",
-        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.12.3.tar.gz"],
-        sha256 = "71030a04aedf9f612d2991c1c552317038c3c5a2b578ac4745267a45e7037c29",
-        strip_prefix = "protobuf-3.12.3",
-    )
+
+http_archive(
+    name = "com_google_protobuf",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.12.3.tar.gz"],
+    sha256 = "71030a04aedf9f612d2991c1c552317038c3c5a2b578ac4745267a45e7037c29",
+    strip_prefix = "protobuf-3.12.3",
+)
+
+
 
 load("@com_google_zetasql//bazel:zetasql_deps_step_1.bzl", "zetasql_deps_step_1")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -176,7 +176,7 @@ google_cloud_cpp_common_deps()
 
 http_archive(
     name = "libprotobuf_mutator",
-    build_file = '@com_google_cloud_spanner_emulator_fuzzing//:third_party/envoy/libprotobuf_mutator.BUILD',
+    build_file = '@//:third_party/envoy/libprotobuf_mutator.BUILD',
     strip_prefix = "libprotobuf-mutator-master",
     urls = ["https://github.com/google/libprotobuf-mutator/archive/master.tar.gz"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -193,13 +193,12 @@ bazel_skylib_workspace()
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 protobuf_deps()
 
-if not native.existing_rule("libprotobuf_mutator"):
-    http_archive(
-        name = "libprotobuf_mutator",
-        build_file = '@com_google_zetasql//:third_party/envoy/libprotobuf_mutator.BUILD',
-        strip_prefix = "libprotobuf-mutator-master",
-        urls = ["https://github.com/google/libprotobuf-mutator/archive/master.tar.gz"],
-    )
+http_archive(
+    name = "libprotobuf_mutator",
+    build_file = '@com_google_zetasql//:third_party/envoy/libprotobuf_mutator.BUILD',
+    strip_prefix = "libprotobuf-mutator-master",
+    urls = ["https://github.com/google/libprotobuf-mutator/archive/master.tar.gz"],
+)
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 rules_proto_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
+workspace(name = "com_google_cloud_spanner_emulator_fuzzing")
+
 # Emulator and CPP API dependencies
 
 git_repository(
@@ -183,7 +185,7 @@ http_archive(
 
 http_archive(
     name = "libprotobuf_mutator",
-    build_file = '//third_party/envoy/libprotobuf_mutator.BUILD',
+    build_file = '@com_google_cloud_spanner_emulator_fuzzing//:third_party/envoy/libprotobuf_mutator.BUILD',
     strip_prefix = "libprotobuf-mutator-master",
     urls = ["https://github.com/google/libprotobuf-mutator/archive/master.tar.gz"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -172,23 +172,21 @@ load("@com_github_googleapis_google_cloud_cpp_common//bazel:google_cloud_cpp_com
 
 google_cloud_cpp_common_deps()
 
-if not native.existing_rule("bazel_skylib"):
-    http_archive(
-        name = "bazel_skylib",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
-        ],
-        sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
-    )
+http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+    ],
+    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
+)
 
-if not native.existing_rule("libprotobuf_mutator"):
-    http_archive(
-        name = "libprotobuf_mutator",
-        build_file = '//:third_party/envoy/libprotobuf_mutator.BUILD',
-        strip_prefix = "libprotobuf-mutator-master",
-        urls = ["https://github.com/google/libprotobuf-mutator/archive/master.tar.gz"],
-    )
+http_archive(
+    name = "libprotobuf_mutator",
+    build_file = '//:third_party/envoy/libprotobuf_mutator.BUILD',
+    strip_prefix = "libprotobuf-mutator-master",
+    urls = ["https://github.com/google/libprotobuf-mutator/archive/master.tar.gz"],
+)
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -133,15 +133,12 @@ http_archive(
     sha256 = "35072a210111eb478d4cbc005496b4df026131127e2bf26a369d269b679a91ff",
 )
 
-
 http_archive(
     name = "com_google_protobuf",
     urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.12.3.tar.gz"],
     sha256 = "71030a04aedf9f612d2991c1c552317038c3c5a2b578ac4745267a45e7037c29",
     strip_prefix = "protobuf-3.12.3",
 )
-
-
 
 load("@com_google_zetasql//bazel:zetasql_deps_step_1.bzl", "zetasql_deps_step_1")
 
@@ -177,16 +174,6 @@ google_cloud_cpp_common_deps()
 http_archive(
     name = "libprotobuf_mutator",
     build_file = '@//:third_party/envoy/libprotobuf_mutator.BUILD',
-    strip_prefix = "libprotobuf-mutator-master",
-    urls = ["https://github.com/google/libprotobuf-mutator/archive/master.tar.gz"],
-)
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-protobuf_deps()
-
-http_archive(
-    name = "libprotobuf_mutator",
-    build_file = '@com_google_zetasql//third_party/envoy/libprotobuf_mutator.BUILD',
     strip_prefix = "libprotobuf-mutator-master",
     urls = ["https://github.com/google/libprotobuf-mutator/archive/master.tar.gz"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -186,7 +186,7 @@ protobuf_deps()
 
 http_archive(
     name = "libprotobuf_mutator",
-    build_file = '@com_google_zetasql//:third_party/envoy/libprotobuf_mutator.BUILD',
+    build_file = '@com_google_zetasql//third_party/envoy/libprotobuf_mutator.BUILD',
     strip_prefix = "libprotobuf-mutator-master",
     urls = ["https://github.com/google/libprotobuf-mutator/archive/master.tar.gz"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -131,6 +131,15 @@ http_archive(
     sha256 = "35072a210111eb478d4cbc005496b4df026131127e2bf26a369d269b679a91ff",
 )
 
+# Protobuf
+if not native.existing_rule("com_google_protobuf"):
+    http_archive(
+        name = "com_google_protobuf",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.12.3.tar.gz"],
+        sha256 = "71030a04aedf9f612d2991c1c552317038c3c5a2b578ac4745267a45e7037c29",
+        strip_prefix = "protobuf-3.12.3",
+    )
+
 load("@com_google_zetasql//bazel:zetasql_deps_step_1.bzl", "zetasql_deps_step_1")
 
 zetasql_deps_step_1()
@@ -161,6 +170,41 @@ google_cloud_cpp_spanner_deps()
 load("@com_github_googleapis_google_cloud_cpp_common//bazel:google_cloud_cpp_common_deps.bzl", "google_cloud_cpp_common_deps")
 
 google_cloud_cpp_common_deps()
+
+if not native.existing_rule("bazel_skylib"):
+    http_archive(
+        name = "bazel_skylib",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+        ],
+        sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
+    )
+
+if not native.existing_rule("libprotobuf_mutator"):
+    http_archive(
+        name = "libprotobuf_mutator",
+        build_file = '//:third_party/envoy/libprotobuf_mutator.BUILD',
+        strip_prefix = "libprotobuf-mutator-master",
+        urls = ["https://github.com/google/libprotobuf-mutator/archive/master.tar.gz"],
+    )
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+protobuf_deps()
+
+if not native.existing_rule("libprotobuf_mutator"):
+    http_archive(
+        name = "libprotobuf_mutator",
+        build_file = '@com_google_zetasql//:third_party/envoy/libprotobuf_mutator.BUILD',
+        strip_prefix = "libprotobuf-mutator-master",
+        urls = ["https://github.com/google/libprotobuf-mutator/archive/master.tar.gz"],
+    )
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()
 
 ################################################################################
 # Go Build Support                                                             #

--- a/src/fuzz/BUILD
+++ b/src/fuzz/BUILD
@@ -17,7 +17,7 @@ cc_binary(
 
 cc_library(
   name = "spanner_emulator_ddl_statement_to_string",
-  srcs = ["spanner_emulator_ddl_statement_proto_to_string.cc",],
+  srcs = ["protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.cc",],
   deps = [
     ":spanner_emulator_ddl_statement_cc_proto",
     "@com_google_absl//absl/strings:strings",
@@ -32,7 +32,7 @@ cc_proto_library(
 proto_library(
   name = "spanner_emulator_ddl_statement_proto",
   srcs = [
-    "spanner_ddl.proto",
-    "create_table.proto",
+    "protobufs/spanner_ddl.proto",
+    "protobufs/create_table.proto",
   ]
 )

--- a/src/fuzz/BUILD
+++ b/src/fuzz/BUILD
@@ -15,3 +15,24 @@ cc_binary(
   ]
 )
 
+cc_library(
+  name = "spanner_emulator_ddl_statement_to_string",
+  srcs = ["spanner_emulator_ddl_statement_proto_to_string.cc",],
+  deps = [
+    ":spanner_emulator_ddl_statement_cc_proto",
+    "@com_google_absl//absl/strings:strings",
+    ]
+)
+
+cc_proto_library(
+  name = "spanner_emulator_ddl_statement_cc_proto",
+  deps = [":spanner_emulator_ddl_statement_proto",]
+)
+
+proto_library(
+  name = "spanner_emulator_ddl_statement_proto",
+  srcs = [
+    "spanner_ddl.proto",
+    "create_table.proto",
+  ]
+)

--- a/src/fuzz/BUILD
+++ b/src/fuzz/BUILD
@@ -15,13 +15,42 @@ cc_binary(
   ]
 )
 
+cc_binary(
+  name = "create_table_fuzz_test",
+  srcs = [
+    "create_table_fuzz_test.cc",
+    "oss_fuzz.h"
+  ],
+  linkopts = [ "$(LIB_FUZZING_ENGINE)" ],
+  deps = [
+    "@com_google_cloud_spanner_emulator//frontend/server",
+    "@com_github_googleapis_google_cloud_cpp_spanner//google/cloud/spanner:spanner_client",
+    "@com_google_absl//absl/strings:strings",
+    "@com_google_zetasql//zetasql/base:logging",
+    "@libprotobuf_mutator//:libprotobuf_mutator",
+    ":spanner_emulator_ddl_statement_cc_proto",
+    ":spanner_emulator_ddl_statement_to_string"
+  ]
+)
+
+cc_test(
+    name = "spanner_emulator_ddl_statement_proto_to_string_test",
+    srcs = ["spanner_emulator_ddl_statement_proto_to_string_test.cc"],
+    deps = [
+        ":spanner_emulator_ddl_statement_cc_proto",
+        ":spanner_emulator_ddl_statement_to_string",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
   name = "spanner_emulator_ddl_statement_to_string",
   srcs = ["protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.cc",],
   deps = [
     ":spanner_emulator_ddl_statement_cc_proto",
     "@com_google_absl//absl/strings:strings",
-    ]
+  ],
+  hdrs = ["protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.h",]
 )
 
 cc_proto_library(

--- a/src/fuzz/BUILD
+++ b/src/fuzz/BUILD
@@ -33,15 +33,16 @@ cc_test(
     name = "spanner_emulator_ddl_statement_proto_to_string_test",
     srcs = ["spanner_emulator_ddl_statement_proto_to_string_test.cc"],
     deps = [
-        ":spanner_emulator_ddl_statement_cc_proto",
-        ":spanner_emulator_ddl_statement_to_string",
-        "@com_google_googletest//:gtest_main",
+      ":spanner_emulator_ddl_statement_cc_proto",
+      ":spanner_emulator_ddl_statement_to_string",
+      "@com_google_googletest//:gtest_main",
     ],
 )
 
 cc_library(
   name = "oss_fuzz_init",
-  srcs = ["oss_fuzz.h"]
+  srcs = ["oss_fuzz.h"],
+  deps = ["@com_google_zetasql//zetasql/base:logging",]
 )
 
 cc_library(

--- a/src/fuzz/BUILD
+++ b/src/fuzz/BUILD
@@ -2,7 +2,10 @@
 
 cc_binary(
   name = "simple_fuzz_test",
-  srcs = ["simple_fuzz_test.cc"],
+  srcs = [
+    "simple_fuzz_test.cc", 
+    "oss_fuzz.h"
+  ],
   linkopts = [ "$(LIB_FUZZING_ENGINE)" ],
   deps = [
     "@com_google_cloud_spanner_emulator//frontend/server",
@@ -11,3 +14,4 @@ cc_binary(
     "@com_google_zetasql//zetasql/base:logging",
   ]
 )
+

--- a/src/fuzz/BUILD
+++ b/src/fuzz/BUILD
@@ -2,25 +2,20 @@
 
 cc_binary(
   name = "simple_fuzz_test",
-  srcs = [
-    "simple_fuzz_test.cc", 
-    "oss_fuzz.h"
-  ],
+  srcs = ["simple_fuzz_test.cc"],
   linkopts = [ "$(LIB_FUZZING_ENGINE)" ],
   deps = [
     "@com_google_cloud_spanner_emulator//frontend/server",
     "@com_github_googleapis_google_cloud_cpp_spanner//google/cloud/spanner:spanner_client",
     "@com_google_absl//absl/strings:strings",
     "@com_google_zetasql//zetasql/base:logging",
+    ":oss_fuzz_init"
   ]
 )
 
 cc_binary(
   name = "create_table_fuzz_test",
-  srcs = [
-    "create_table_fuzz_test.cc",
-    "oss_fuzz.h"
-  ],
+  srcs = ["create_table_fuzz_test.cc"],
   linkopts = [ "$(LIB_FUZZING_ENGINE)" ],
   deps = [
     "@com_google_cloud_spanner_emulator//frontend/server",
@@ -29,7 +24,8 @@ cc_binary(
     "@com_google_zetasql//zetasql/base:logging",
     "@libprotobuf_mutator//:libprotobuf_mutator",
     ":spanner_emulator_ddl_statement_cc_proto",
-    ":spanner_emulator_ddl_statement_to_string"
+    ":spanner_emulator_ddl_statement_to_string",
+    ":oss_fuzz_init"
   ]
 )
 
@@ -41,6 +37,11 @@ cc_test(
         ":spanner_emulator_ddl_statement_to_string",
         "@com_google_googletest//:gtest_main",
     ],
+)
+
+cc_library(
+  name = "oss_fuzz_init",
+  srcs = ["oss_fuzz.h"]
 )
 
 cc_library(

--- a/src/fuzz/create_table_fuzz_test.cc
+++ b/src/fuzz/create_table_fuzz_test.cc
@@ -1,0 +1,128 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "libprotobuf_mutator/src/libfuzzer/libfuzzer_macro.h"
+
+#include "src/fuzz/protobufs/create_table.pb.h"
+#include "src/fuzz/protobufs/spanner_ddl.pb.h"
+#include "src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include "src/fuzz/oss_fuzz.h"
+
+#include "zetasql/base/logging.h"
+#include "frontend/server/server.h"
+#include "google/cloud/spanner/client.h"
+#include "google/cloud/spanner/create_instance_request_builder.h"
+#include "google/cloud/spanner/database_admin_client.h"
+#include "google/cloud/spanner/instance_admin_client.h"
+
+using ::google::spanner::emulator::frontend::Server;
+using ::google::cloud::future;
+using ::google::cloud::StatusOr;
+using ::google::cloud::spanner::DatabaseAdminClient;
+using ::google::cloud::spanner::v0::ConnectionOptions;
+using spanner_ddl::CreateTable;
+
+const std::string server_address = "localhost:1234";
+
+DEFINE_PROTO_FUZZER(const CreateTable& createTable) {
+  #ifdef __OSS_FUZZ__
+    static bool Initialized = spanner_emulator_fuzzer::DoOssFuzzInit();
+    if (!Initialized) { std::abort(); }
+  #endif
+
+  Server::Options options;
+  options.server_address = server_address;
+  std::unique_ptr<Server> server = Server::Create(options);
+  if (!server) {
+    return EXIT_FAILURE;
+  }
+
+  LOG(INFO) << "Server Up, Executing Test Query";
+
+  try {
+    // This is the connection to the emulator.
+    ConnectionOptions emulator_connection;
+    emulator_connection.set_endpoint(server_address)
+        .set_credentials(grpc::InsecureChannelCredentials());
+
+    // First we create an instance to create our database on.
+    google::cloud::spanner::Instance instance("emulator", "emulator");
+    google::cloud::spanner::InstanceAdminClient instance_client(
+        google::cloud::spanner::MakeInstanceAdminConnection(
+            emulator_connection));
+
+    auto instance_or = instance_client.CreateInstance(
+            google::cloud::spanner::CreateInstanceRequestBuilder(instance,
+                                                                 "emulator")
+                .SetDisplayName("emulator")
+                .SetNodeCount(1)
+                .SetLabels({{"label-key", "label-value"}})
+                .Build())
+                .get();
+    if (!instance_or) {
+      throw std::runtime_error(instance_or.status().message());
+    }
+    LOG(INFO) << "Created instance [" << instance << "]";
+
+    // Then we create a simple database.
+    google::cloud::spanner::Database database(instance, "test-db");
+
+    auto admin_client =
+        DatabaseAdminClient(google::cloud::spanner::MakeDatabaseAdminConnection(
+            emulator_connection));
+    auto db_or =
+        admin_client.CreateDatabase(database, {R"sdl(
+          CREATE TABLE Singers (
+              SingerId   INT64 NOT NULL,
+              FirstName  STRING(1024),
+              LastName   STRING(1024),
+              SingerInfo BYTES(MAX)
+          ) PRIMARY KEY (SingerId))sdl",
+                                               R"sdl(
+          CREATE TABLE Albums (
+              SingerId     INT64 NOT NULL,
+              AlbumId      INT64 NOT NULL,
+              AlbumTitle   STRING(MAX)
+          ) PRIMARY KEY (SingerId, AlbumId),
+              INTERLEAVE IN PARENT Singers ON DELETE CASCADE)sdl"})
+            .get();
+    if (!db_or) throw std::runtime_error(db_or.status().message());
+    LOG(INFO) << "Created database [" << database << "]";
+
+    google::cloud::spanner::Client client(
+        google::cloud::spanner::MakeConnection(database, emulator_connection));
+
+    std::string query = toString(createTable);
+
+    client.ExecuteQuery(
+        google::cloud::spanner::SqlStatement(query)
+    );
+
+    return 0;
+  } catch (std::exception const& ex) {
+    LOG(ERROR) << "Standard exception raised: " << ex.what();
+    return 1;
+  }
+
+  server->Shutdown();
+
+  return 0;  
+}
+

--- a/src/fuzz/create_table_fuzz_test.cc
+++ b/src/fuzz/create_table_fuzz_test.cc
@@ -93,13 +93,14 @@ DEFINE_PROTO_FUZZER(const CreateTable& createTable) {
         auto db_or =
         admin_client.CreateDatabase(database, {createTableDDLStatement})
             .get();
+        if (!db_or) throw std::runtime_error(db_or.status().message());
+
     } catch (std::exception const& ex) {
         LOG(ERROR) << "Failed to create table with the following DDL statement:";
         LOG(ERROR) << createTableDDLStatement;
         return 1;
     }
     
-    if (!db_or) throw std::runtime_error(db_or.status().message());
     LOG(INFO) << "Created database [" << database << "]";
     LOG(INFO) << "Ran following statement: " << createTableDDLStatement;
 

--- a/src/fuzz/oss_fuzz.h
+++ b/src/fuzz/oss_fuzz.h
@@ -20,6 +20,7 @@
 #define SPANNER_EMULATOR_FUZZING_OSS_FUZZ_H_
 
 #include <filesystem>
+#include "zetasql/base/logging.h"
 
 const int OVERWRITE = 1;
 
@@ -31,11 +32,13 @@ bool DoOssFuzzInit() {
   try {
     originDir = fs::canonical(fs::read_symlink("/proc/self/exe")).parent_path();
   } catch (const std::exception& e) {
+    LOG(ERROR) << "Error - Cannot initialize OSS-Fuzz";
     return false;
   }
   // Timezone data in OSS-Fuzz is in a non-standard location. This allows asbl to know where it resides
   fs::path tzdataDir = originDir / "data/zoneinfo/";
   if (setenv("TZDIR", tzdataDir.c_str(), OVERWRITE)) {
+    LOG(ERROR) << "Error - Timezone data copied incorrectly from OSS-Fuzz build";
     return false;
   }
   return true;

--- a/src/fuzz/oss_fuzz.h
+++ b/src/fuzz/oss_fuzz.h
@@ -1,0 +1,47 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Utilities for OSS-Fuzz Initialization
+
+#if defined(__OSS_FUZZ__) && !defined(SPANNER_EMULATOR_FUZZING_OSS_FUZZ_H_)
+#define SPANNER_EMULATOR_FUZZING_OSS_FUZZ_H_
+
+#include <filesystem>
+
+const int OVERWRITE = 1;
+
+namespace spanner_emulator_fuzzer {
+
+bool DoOssFuzzInit() {
+  namespace fs = std::filesystem;
+  fs::path originDir;
+  try {
+    originDir = fs::canonical(fs::read_symlink("/proc/self/exe")).parent_path();
+  } catch (const std::exception& e) {
+    return false;
+  }
+  // Timezone data in OSS-Fuzz is in a non-standard location. This allows asbl to know where it resides
+  fs::path tzdataDir = originDir / "data/zoneinfo/";
+  if (setenv("TZDIR", tzdataDir.c_str(), OVERWRITE)) {
+    return false;
+  }
+  return true;
+}
+
+}  
+
+#endif  
+

--- a/src/fuzz/protobufs/create_table.proto
+++ b/src/fuzz/protobufs/create_table.proto
@@ -1,0 +1,60 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto2";
+
+package spanner_ddl;
+
+// represents if a column's data is scalar/an array and its scalar type
+message ColumnDataInfo {}
+    required bool isArray = 1;
+    enum Scalartypes {
+        BOOL = 0;
+        INT64 = 1;
+        FLOAT64 = 2;
+        STRING = 3;
+        BYTES = 4;
+        DATE = 5;
+        TIMESTAMP = 6;
+    }
+    required Scalartypes = 2;
+    // represents the length for string/byte types
+    required int32 length = 3;
+}
+
+// represents a column of a table
+message Column {
+    required string columnName = 1;
+    
+    required ColumnDataInfo columnInfo = 2;
+    required bool isNull = 3;
+    required bool allowCommitTimestamp = 4;
+
+    // only used for primary keys
+    enum Orientation {
+        ASC = 0;
+        DESC = 1;
+    }
+    required Orientation orientation = 5 [default = ASC];
+}
+
+
+//represents a table
+message CreateTable {
+    required string tableName = 0;
+    repeated Column primaryKeys = 1;
+    repeated Column nonPrimaryKeys = 2;
+}

--- a/src/fuzz/protobufs/create_table.proto
+++ b/src/fuzz/protobufs/create_table.proto
@@ -19,7 +19,7 @@ syntax = "proto2";
 package spanner_ddl;
 
 // represents if a column's data is scalar/an array and its scalar type
-message ColumnDataInfo {
+message ColumnDataType {
     required bool isArray = 1;
     enum ScalarType {
         BOOL = 0;
@@ -46,7 +46,7 @@ message ColumnDataInfo {
 message Column {
     required string columnName = 1;
     
-    required ColumnDataInfo columnDataInfo = 2;
+    required ColumnDataType columnDataType = 2;
     required bool isNotNull = 3;
     required bool allowCommitTimestamp = 4;
 

--- a/src/fuzz/protobufs/create_table.proto
+++ b/src/fuzz/protobufs/create_table.proto
@@ -58,8 +58,7 @@ message Column {
     required Orientation orientation = 5 [default = ASC];
 }
 
-
-//represents a table
+// represents a 'CREATE TABLE' statement
 message CreateTable {
     required string tableName = 1;
     repeated Column primaryKeys = 2;

--- a/src/fuzz/protobufs/create_table.proto
+++ b/src/fuzz/protobufs/create_table.proto
@@ -48,6 +48,8 @@ message Column {
     
     required ColumnDataType columnDataType = 2;
     required bool isNotNull = 3;
+    //TODO: make timestamps optional and add corresponding changes
+    // to the parsing methods
     required bool allowCommitTimestamp = 4;
 
     // only used for primary keys
@@ -55,6 +57,8 @@ message Column {
         ASC = 0;
         DESC = 1;
     }
+    //TODO: make orientation optional and add corresponding changes
+    // to the parsing methods
     required Orientation orientation = 5 [default = ASC];
 }
 

--- a/src/fuzz/protobufs/create_table.proto
+++ b/src/fuzz/protobufs/create_table.proto
@@ -30,9 +30,16 @@ message ColumnDataInfo {
         DATE = 5;
         TIMESTAMP = 6;
     }
-    required ScalarType type = 2;
+    required ScalarType scalarType = 2;
     // represents the length for string/byte types
     required int32 length = 3;
+
+    enum LengthType {
+        BOUND = 0;
+        UNBOUND = 1;
+        MAX = 2;
+    }
+    required LengthType lengthType = 4;
 }
 
 // represents a column of a table

--- a/src/fuzz/protobufs/create_table.proto
+++ b/src/fuzz/protobufs/create_table.proto
@@ -19,9 +19,9 @@ syntax = "proto2";
 package spanner_ddl;
 
 // represents if a column's data is scalar/an array and its scalar type
-message ColumnDataInfo {}
+message ColumnDataInfo {
     required bool isArray = 1;
-    enum Scalartypes {
+    enum ScalarType {
         BOOL = 0;
         INT64 = 1;
         FLOAT64 = 2;
@@ -30,7 +30,7 @@ message ColumnDataInfo {}
         DATE = 5;
         TIMESTAMP = 6;
     }
-    required Scalartypes = 2;
+    required ScalarType type = 2;
     // represents the length for string/byte types
     required int32 length = 3;
 }
@@ -39,8 +39,8 @@ message ColumnDataInfo {}
 message Column {
     required string columnName = 1;
     
-    required ColumnDataInfo columnInfo = 2;
-    required bool isNull = 3;
+    required ColumnDataInfo columnDataInfo = 2;
+    required bool isNotNull = 3;
     required bool allowCommitTimestamp = 4;
 
     // only used for primary keys
@@ -54,7 +54,7 @@ message Column {
 
 //represents a table
 message CreateTable {
-    required string tableName = 0;
-    repeated Column primaryKeys = 1;
-    repeated Column nonPrimaryKeys = 2;
+    required string tableName = 1;
+    repeated Column primaryKeys = 2;
+    repeated Column nonPrimaryKeys = 3;
 }

--- a/src/fuzz/protobufs/spanner_ddl.proto
+++ b/src/fuzz/protobufs/spanner_ddl.proto
@@ -1,0 +1,33 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import "create_database.proto";
+
+syntax = "proto2";
+
+package spanner_ddl;
+
+
+message SpannerDDLStatement {
+    oneof DDLStatement {
+        // add new statement types here
+        CreateTable createTable = 0;
+    }
+}
+
+message SpannerFuzzingStatements {
+    repeated SpannerDDLMessage statements = 1;
+}

--- a/src/fuzz/protobufs/spanner_ddl.proto
+++ b/src/fuzz/protobufs/spanner_ddl.proto
@@ -18,10 +18,7 @@ syntax = "proto2";
 
 import "src/fuzz/protobufs/create_table.proto";
 
-
-
 package spanner_ddl;
-
 
 message SpannerDDLStatement {
     oneof DDLStatement {

--- a/src/fuzz/protobufs/spanner_ddl.proto
+++ b/src/fuzz/protobufs/spanner_ddl.proto
@@ -14,9 +14,11 @@
 // limitations under the License.
 //
 
-import "create_database.proto";
-
 syntax = "proto2";
+
+import "src/fuzz/protobufs/create_table.proto";
+
+
 
 package spanner_ddl;
 
@@ -24,10 +26,10 @@ package spanner_ddl;
 message SpannerDDLStatement {
     oneof DDLStatement {
         // add new statement types here
-        CreateTable createTable = 0;
+        CreateTable createTable = 1;
     }
 }
 
 message SpannerFuzzingStatements {
-    repeated SpannerDDLMessage statements = 1;
+    repeated SpannerDDLStatement statements = 1;
 }

--- a/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.cc
+++ b/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.cc
@@ -195,7 +195,7 @@ std::string toPrimaryKeys(const RepeatedPtrField<Column>& columns) {
 }
 
 std::string columnToPrimaryKey(const Column& column) {
-    return absl::Substitute("$0 [ { $1 } ],", column.columnname(), 
+    return absl::Substitute("$0 $1,", column.columnname(), 
         toString(column.orientation()));
 }
 

--- a/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.cc
+++ b/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.cc
@@ -1,0 +1,70 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "src/fuzz/protobufs/create_table.pb.h"
+#include "src/fuzz/protobufs/spanner_ddl.pb.h"
+
+#include <google/protobuf/repeated_field.h>
+namespace google::protobuf
+
+#include <string>
+
+using spanner_ddl::SpannerDDLStatement;
+using create_table::CreateTable;
+using create_table::Column;
+
+
+
+std::string toString(SpannerDDLStatement statement) {
+    using statementType = SpannerDDLStatement::DDLStatementCase;
+    switch (statement.DDLStatement_case()) {
+        case statementType::kCreateTable:
+            return toString(statement.createTable());
+        //TODO: add more cases here for additional APIs
+        default:
+            return "";
+    }
+}
+
+std::string toString(CreateTable createTable) {
+    return absl::Substitute("CREATE TABLE $0 ($1, $2) PRIMARY KEY ($3)", 
+                createTable.tableName(), 
+                toString(createTable.primaryKeys()),
+                toString(createTable.nonPrimaryKeys()),
+                toPrimaryKeys(createTable.primaryKeys()));
+}
+
+// converts a list of columns to a string format of [column1], [column2], ...
+std::string toString(RepeatedPtrField<Column>& columns) {
+    std:string columnsAsString = "";
+    for (int i = 0; i < columns.size(); i++) {
+        Column currCol = columns.at(i);
+        absl::StrAppend(&columnsAsString, toString(currCol));
+    }
+    // toString(currCol) will have an extra comma at the end so chop it off
+    columnAsString = columnAsString.substring(0, columnAsString.size() - 1);
+    return columnsAsString;
+}
+
+std::string toString(Column& column) {
+    return "";
+}
+
+std::string toPrimaryKeys(RepeatedPtrField<Column>& columns) {
+    return "";
+}
+
+

--- a/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.cc
+++ b/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.cc
@@ -18,53 +18,135 @@
 #include "src/fuzz/protobufs/spanner_ddl.pb.h"
 
 #include <google/protobuf/repeated_field.h>
-namespace google::protobuf
 
 #include <string>
+#include "absl/strings/substitute.h"
+#include "absl/strings/str_cat.h"
 
 using spanner_ddl::SpannerDDLStatement;
-using create_table::CreateTable;
-using create_table::Column;
+using spanner_ddl::CreateTable;
+using spanner_ddl::Column;
+using spanner_ddl::ColumnDataInfo;
 
 
+// forward declarations
+std::string toString(SpannerDDLStatement statement);
+std::string toString(CreateTable createTable);
+std::string toString(const google::protobuf::RepeatedPtrField<Column> columns);
+std::string toString(Column column);
+std::string toString(ColumnDataInfo columnDataInfo);
+std::string toString(ColumnDataInfo::ScalarType type, int length);
+std::string isColumnNotNullToString(bool isNotNull);
+std::string columnOptionsToString(bool allowCommitTimestamps);
+std::string toPrimaryKeys(const google::protobuf::RepeatedPtrField<Column>& columns);
+std::string columnToPrimaryKey(Column column);
+std::string toString(Column::Orientation orientation);
 
+
+// takes any Spanner DDL statement and returns an appropriate string for the emulator
 std::string toString(SpannerDDLStatement statement) {
     using statementType = SpannerDDLStatement::DDLStatementCase;
     switch (statement.DDLStatement_case()) {
         case statementType::kCreateTable:
-            return toString(statement.createTable());
+            return toString(statement.createtable());
         //TODO: add more cases here for additional APIs
         default:
             return "";
     }
 }
 
+// generates a 'CREATE TABLE ...' statement
 std::string toString(CreateTable createTable) {
-    return absl::Substitute("CREATE TABLE $0 ($1, $2) PRIMARY KEY ($3)", 
-                createTable.tableName(), 
-                toString(createTable.primaryKeys()),
-                toString(createTable.nonPrimaryKeys()),
-                toPrimaryKeys(createTable.primaryKeys()));
+    return absl::Substitute("CREATE TABLE $0 ([ $1,$2 ]) PRIMARY KEY ( [$3] )", 
+                createTable.tablename(), 
+                toString(createTable.primarykeys()),
+                toString(createTable.nonprimarykeys()),
+                toPrimaryKeys(createTable.primarykeys()));
 }
 
-// converts a list of columns to a string format of [column1], [column2], ...
-std::string toString(RepeatedPtrField<Column>& columns) {
-    std:string columnsAsString = "";
+// converts a list of columns to a string format of {column1},{column2},...
+std::string toString(const google::protobuf::RepeatedPtrField<Column> columns) {
+    std::string columnsAsString = "";
     for (int i = 0; i < columns.size(); i++) {
-        Column currCol = columns.at(i);
+        const Column& currCol = columns.at(i);
         absl::StrAppend(&columnsAsString, toString(currCol));
     }
     // toString(currCol) will have an extra comma at the end so chop it off
-    columnAsString = columnAsString.substring(0, columnAsString.size() - 1);
+    columnsAsString = columnsAsString.substr(0, columnsAsString.size() - 1);
     return columnsAsString;
 }
 
-std::string toString(Column& column) {
-    return "";
+std::string toString(Column column) {
+    return absl::Substitute("{ $0 $1 $2 $3 },", 
+        column.columnname(), 
+        toString(column.columndatainfo()), 
+        isColumnNotNullToString(column.isnotnull()),
+        columnOptionsToString(column.allowcommittimestamp()));
 }
 
-std::string toPrimaryKeys(RepeatedPtrField<Column>& columns) {
-    return "";
+// returns "data_type" or "ARRAY< data_type >" based on ColumnDataInfo
+std::string toString(ColumnDataInfo columnDataInfo) {
+    return columnDataInfo.isarray() ? 
+        absl::Substitute("ARRAY< $0 >", toString(columnDataInfo.type(), columnDataInfo.length())) :
+        toString(columnDataInfo.type(), columnDataInfo.length());
 }
 
+// returns the column's scalar type as a string
+std::string toString(ColumnDataInfo::ScalarType type, int length) {
+    switch (type) {
+        case ColumnDataInfo::BOOL:
+            return "BOOL";
+        case ColumnDataInfo::INT64:
+            return "INT64";
+        case ColumnDataInfo::FLOAT64:
+            return "FLOAT64";
+        case ColumnDataInfo::STRING:
+            return absl::Substitute("STRING( $0 )", std::to_string(length));
+        case ColumnDataInfo::BYTES:
+            return absl::Substitute("BYTES( $0 )", std::to_string(length));
+        case ColumnDataInfo::DATE:
+            return "DATE";
+        case ColumnDataInfo::TIMESTAMP:
+            return "TIMESTAMP";
+        default: // never occurs given the protobuf structure
+            return "";
+    }
+}
+
+// if this column should be not null, return the appropriate string
+std::string isColumnNotNullToString(bool isNotNull) {
+    return isNotNull ? "[ NOT NULL ]" : "";
+}
+
+// return the options for this column as a string
+// the current api only allows for timestamps
+std::string columnOptionsToString(bool allowCommitTimestamps) {
+    std::string allowTimestamps = allowCommitTimestamps ? "true" : "null";
+    return absl::Substitute("{ OPTIONS ( allow_commit_timestamp = { $0 } ) }", allowTimestamps);
+}
+
+std::string toPrimaryKeys(const google::protobuf::RepeatedPtrField<Column>& columns) {
+    std::string primaryKeysAsString = "";
+    for (int i = 0; i < columns.size(); i++) {
+        const Column& currCol = columns.at(i);
+        absl::StrAppend(&primaryKeysAsString, columnToPrimaryKey(currCol));
+    }
+    // chop off an extra "," at the end
+    primaryKeysAsString = primaryKeysAsString.substr(0, primaryKeysAsString.size() - 1);
+
+    return primaryKeysAsString;
+}
+
+std::string columnToPrimaryKey(Column column) {
+    return absl::Substitute("$0 [ { $1 } ],", column.columnname(), toString(column.orientation()));
+}
+
+std::string toString(Column::Orientation orientation) {
+    switch (orientation) {
+        case Column::ASC:
+            return "ASC";
+        default:
+            return "DESC";
+    }
+}
 

--- a/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.cc
+++ b/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.cc
@@ -34,16 +34,16 @@ using google::protobuf::RepeatedPtrField;
 
 // forward declarations
 std::string toString(const SpannerDDLStatement& statement);
-std::string toString(const CreateTable& createTable);
+std::string toString(const CreateTable& create_table);
 std::string tableColumnsToString(const RepeatedPtrField<Column>& primary_keys,
     const RepeatedPtrField<Column>& non_primary_keys);
 std::string toString(const RepeatedPtrField<Column>& columns);
 std::string toString(const Column& column);
-std::string toString(const ColumnDataType& columnDataType);
-std::string toString(const ColumnDataType::ScalarType& type, int length, 
-    const ColumnDataType::LengthType& lengthType);
-std::string isColumnNotNullToString(bool isNotNull);
-std::string columnOptionsToString(bool allowCommitTimestamps);
+std::string toString(const ColumnDataType& column_data_type);
+std::string toString(const ColumnDataType::ScalarType& scalar_type, int length, 
+    const ColumnDataType::LengthType& length_type);
+std::string isColumnNotNullToString(bool is_not_null);
+std::string columnOptionsToString(bool allow_commit_timestamps);
 std::string toPrimaryKeys(const RepeatedPtrField<Column>& columns);
 std::string columnToPrimaryKey(const Column& column);
 std::string toString(const Column::Orientation& orientation);
@@ -61,12 +61,12 @@ std::string toString(const SpannerDDLStatement& statement) {
 }
 
 // generates a 'CREATE TABLE ...' statement
-std::string toString(const CreateTable& createTable) {
+std::string toString(const CreateTable& create_table) {
     return absl::Substitute("CREATE TABLE $0 ( $1 ) PRIMARY KEY ( $2 )",
-                createTable.tablename(), 
-                tableColumnsToString(createTable.primarykeys(), 
-                    createTable.nonprimarykeys()),
-                toPrimaryKeys(createTable.primarykeys()));
+                create_table.tablename(), 
+                tableColumnsToString(create_table.primarykeys(), 
+                    create_table.nonprimarykeys()),
+                toPrimaryKeys(create_table.primarykeys()));
 }
 
 // returns a string representing all columns of the table depending on
@@ -91,11 +91,12 @@ std::string tableColumnsToString(const RepeatedPtrField<Column>& primary_keys,
 // returns an empty string if no columns exist
 std::string toString(const RepeatedPtrField<Column>& columns) {
 
-    std::vector<std::string> columnsAsStrings;
+    std::vector<std::string> columns_as_strings;
     for (const Column& curr_col : columns) {
-        columnsAsStrings.push_back(toString(curr_col));
+        std::string curr_col_as_string = toString(curr_col);
+        columns_as_strings.push_back(curr_col_as_string);
     }
-    return absl::StrJoin(columnsAsStrings, ",");
+    return absl::StrJoin(columns_as_strings, ",");
 }
 
 // A column is { column_name data_type [ NOT NULL ] [ options_def ] }
@@ -110,18 +111,18 @@ std::string toString(const Column& column) {
 }
 
 // returns "data_type" or "ARRAY< data_type >" based on ColumnDataInfo
-std::string toString(const ColumnDataType& columnDataType) {
-    return columnDataType.isarray() ? 
-        absl::Substitute("ARRAY< $0 >", toString(columnDataType.scalartype(), 
-            columnDataType.length(), columnDataType.lengthtype())) :
-        toString(columnDataType.scalartype(), columnDataType.length(), 
-            columnDataType.lengthtype());
+std::string toString(const ColumnDataType& column_data_type) {
+    return column_data_type.isarray() ? 
+        absl::Substitute("ARRAY< $0 >", toString(column_data_type.scalartype(), 
+            column_data_type.length(), column_data_type.lengthtype())) :
+        toString(column_data_type.scalartype(), column_data_type.length(), 
+            column_data_type.lengthtype());
 }
 
 // returns the column's scalar type as a string
-std::string toString(const ColumnDataType::ScalarType& type, int length, 
-    const ColumnDataType::LengthType& lengthType) {
-    switch (type) {
+std::string toString(const ColumnDataType::ScalarType& scalar_type, int length, 
+    const ColumnDataType::LengthType& length_type) {
+    switch (scalar_type) {
         case ColumnDataType::BOOL:
             return "BOOL";
         case ColumnDataType::INT64:
@@ -129,7 +130,7 @@ std::string toString(const ColumnDataType::ScalarType& type, int length,
         case ColumnDataType::FLOAT64:
             return "FLOAT64";
         case ColumnDataType::STRING:
-            switch (lengthType) {
+            switch (length_type) {
                 case ColumnDataType::BOUND:
                     // ensures length is a positive number
                     length = std::abs(length) + 1;
@@ -144,7 +145,7 @@ std::string toString(const ColumnDataType::ScalarType& type, int length,
                     return ""; // never triggers
             }
         case ColumnDataType::BYTES:
-            switch (lengthType) {
+            switch (length_type) {
                 case ColumnDataType::BOUND:
                     // ensures length is a positive number
                     length = std::abs(length) + 1;
@@ -168,34 +169,31 @@ std::string toString(const ColumnDataType::ScalarType& type, int length,
 }
 
 // if this column should be not null, return the appropriate string
-std::string isColumnNotNullToString(bool isNotNull) {
-    return isNotNull ? "NOT NULL" : "";
+std::string isColumnNotNullToString(bool is_not_null) {
+    return is_not_null ? "NOT NULL" : "";
 }
 
 // return the options for this column as a string
 // the current api only allows for timestamps
-std::string columnOptionsToString(bool allowCommitTimestamps) {
-    std::string allowTimestamps = allowCommitTimestamps ? "true" : "null";
+std::string columnOptionsToString(bool allow_commit_timestamps) {
+    std::string allow = allow_commit_timestamps ? "true" : "null";
     return absl::Substitute("OPTIONS ( allow_commit_timestamp = $0 )",
-         allowTimestamps);
+         allow);
 }
 
 // generates a list of the primary keys' column names and their orientations
 std::string toPrimaryKeys(const RepeatedPtrField<Column>& columns) {
-    std::string primaryKeysAsString = "";
-    for (int i = 0; i < columns.size(); i++) {
-        const Column& currCol = columns.at(i);
-        absl::StrAppend(&primaryKeysAsString, columnToPrimaryKey(currCol));
+    std::vector<std::string> columns_as_strings;
+    for (const Column& curr_col : columns) {
+        std::string curr_col_as_string = columnToPrimaryKey(curr_col);
+        columns_as_strings.push_back(curr_col_as_string);
     }
-    // columnToPrimaryKey(currCol) will have an extra comma at the end
-    primaryKeysAsString = primaryKeysAsString.substr(0, 
-        primaryKeysAsString.size() - 1);
-
-    return primaryKeysAsString;
+    // if there are no columns this will return an empty string
+    return absl::StrJoin(columns_as_strings, ",");
 }
 
 std::string columnToPrimaryKey(const Column& column) {
-    return absl::Substitute("$0 $1,", column.columnname(), 
+    return absl::Substitute("$0 $1", column.columnname(), 
         toString(column.orientation()));
 }
 

--- a/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.h
+++ b/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.h
@@ -31,16 +31,16 @@ using google::protobuf::RepeatedPtrField;
 
 // proto to string methods
 std::string toString(const SpannerDDLStatement& statement);
-std::string toString(const CreateTable& createTable);
+std::string toString(const CreateTable& create_table);
 std::string tableColumnsToString(const RepeatedPtrField<Column>& primary_keys,
     const RepeatedPtrField<Column>& non_primary_keys);
 std::string toString(const RepeatedPtrField<Column>& columns);
 std::string toString(const Column& column);
-std::string toString(const ColumnDataType& columnDataType);
-std::string toString(const ColumnDataType::ScalarType& type, int length, 
-    const ColumnDataType::LengthType& lengthType);
-std::string isColumnNotNullToString(bool isNotNull);
-std::string columnOptionsToString(bool allowCommitTimestamps);
+std::string toString(const ColumnDataType& column_data_type);
+std::string toString(const ColumnDataType::ScalarType& scalar_type, int length, 
+    const ColumnDataType::LengthType& length_type);
+std::string isColumnNotNullToString(bool is_not_null);
+std::string columnOptionsToString(bool allow_commit_timestamps);
 std::string toPrimaryKeys(const RepeatedPtrField<Column>& columns);
 std::string columnToPrimaryKey(const Column& column);
 std::string toString(const Column::Orientation& orientation);

--- a/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.h
+++ b/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.h
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+#ifndef SRC_FUZZ_PROTOBUF_UTILS_SPANNER_EMULATOR_DDL_STATEMENT_PROTO_TO_STRING_H
+#define SRC_FUZZ_PROTOBUF_UTILS_SPANNER_EMULATOR_DDL_STATEMENT_PROTO_TO_STRING_H
 
 #include "src/fuzz/protobufs/create_table.pb.h"
 #include "src/fuzz/protobufs/spanner_ddl.pb.h"
@@ -44,3 +46,5 @@ std::string columnOptionsToString(bool allow_commit_timestamps);
 std::string toPrimaryKeys(const RepeatedPtrField<Column>& columns);
 std::string columnToPrimaryKey(const Column& column);
 std::string toString(const Column::Orientation& orientation);
+
+#endif // SRC_FUZZ_PROTOBUF_UTILS_SPANNER_EMULATOR_DDL_STATEMENT_PROTO_TO_STRING_H

--- a/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.h
+++ b/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.h
@@ -26,18 +26,21 @@
 using spanner_ddl::SpannerDDLStatement;
 using spanner_ddl::CreateTable;
 using spanner_ddl::Column;
-using spanner_ddl::ColumnDataInfo;
+using spanner_ddl::ColumnDataType;
+using google::protobuf::RepeatedPtrField;
 
 // proto to string methods
-std::string toString(SpannerDDLStatement statement);
-std::string toString(CreateTable createTable);
-std::string toString(const google::protobuf::RepeatedPtrField<Column> columns);
-std::string toString(Column column);
-std::string toString(ColumnDataInfo columnDataInfo);
-std::string toString(ColumnDataInfo::ScalarType type, int length, 
-    ColumnDataInfo::LengthType lengthType);
+std::string toString(const SpannerDDLStatement& statement);
+std::string toString(const CreateTable& createTable);
+std::string tableColumnsToString(const RepeatedPtrField<Column>& primary_keys,
+    const RepeatedPtrField<Column>& non_primary_keys);
+std::string toString(const RepeatedPtrField<Column>& columns);
+std::string toString(const Column& column);
+std::string toString(const ColumnDataType& columnDataType);
+std::string toString(const ColumnDataType::ScalarType& type, int length, 
+    const ColumnDataType::LengthType& lengthType);
 std::string isColumnNotNullToString(bool isNotNull);
 std::string columnOptionsToString(bool allowCommitTimestamps);
-std::string toPrimaryKeys(const google::protobuf::RepeatedPtrField<Column>& columns);
-std::string columnToPrimaryKey(Column column);
-std::string toString(Column::Orientation orientation);
+std::string toPrimaryKeys(const RepeatedPtrField<Column>& columns);
+std::string columnToPrimaryKey(const Column& column);
+std::string toString(const Column::Orientation& orientation);

--- a/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.h
+++ b/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.h
@@ -28,14 +28,14 @@ using spanner_ddl::CreateTable;
 using spanner_ddl::Column;
 using spanner_ddl::ColumnDataInfo;
 
-
-// forward declarations
+// proto to string methods
 std::string toString(SpannerDDLStatement statement);
 std::string toString(CreateTable createTable);
 std::string toString(const google::protobuf::RepeatedPtrField<Column> columns);
 std::string toString(Column column);
 std::string toString(ColumnDataInfo columnDataInfo);
-std::string toString(ColumnDataInfo::ScalarType type, int length, ColumnDataInfo::LengthType lengthType);
+std::string toString(ColumnDataInfo::ScalarType type, int length, 
+    ColumnDataInfo::LengthType lengthType);
 std::string isColumnNotNullToString(bool isNotNull);
 std::string columnOptionsToString(bool allowCommitTimestamps);
 std::string toPrimaryKeys(const google::protobuf::RepeatedPtrField<Column>& columns);

--- a/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.h
+++ b/src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.h
@@ -1,0 +1,43 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "src/fuzz/protobufs/create_table.pb.h"
+#include "src/fuzz/protobufs/spanner_ddl.pb.h"
+
+#include <google/protobuf/repeated_field.h>
+
+#include <string>
+#include "absl/strings/substitute.h"
+#include "absl/strings/str_cat.h"
+
+using spanner_ddl::SpannerDDLStatement;
+using spanner_ddl::CreateTable;
+using spanner_ddl::Column;
+using spanner_ddl::ColumnDataInfo;
+
+
+// forward declarations
+std::string toString(SpannerDDLStatement statement);
+std::string toString(CreateTable createTable);
+std::string toString(const google::protobuf::RepeatedPtrField<Column> columns);
+std::string toString(Column column);
+std::string toString(ColumnDataInfo columnDataInfo);
+std::string toString(ColumnDataInfo::ScalarType type, int length, ColumnDataInfo::LengthType lengthType);
+std::string isColumnNotNullToString(bool isNotNull);
+std::string columnOptionsToString(bool allowCommitTimestamps);
+std::string toPrimaryKeys(const google::protobuf::RepeatedPtrField<Column>& columns);
+std::string columnToPrimaryKey(Column column);
+std::string toString(Column::Orientation orientation);

--- a/src/fuzz/simple_fuzz_test.cc
+++ b/src/fuzz/simple_fuzz_test.cc
@@ -15,7 +15,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <stdexcept>
-#include "oss_fuzz.h"
+#include "src/fuzz/oss_fuzz.h"
 
 #include "zetasql/base/logging.h"
 #include "frontend/server/server.h"

--- a/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
+++ b/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
@@ -24,12 +24,13 @@
 
 #include "absl/strings/substitute.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
 
 using spanner_ddl::SpannerFuzzingStatements;
 using spanner_ddl::SpannerDDLStatement;
 using spanner_ddl::CreateTable;
 using spanner_ddl::Column;
-using spanner_ddl::ColumnDataInfo;
+using spanner_ddl::ColumnDataType;
 
 //TODO: add more to this test as more APIs are added
 TEST(DDLStatementProtoToString, DDLStatementToString) {
@@ -42,11 +43,11 @@ TEST(DDLStatementProtoToString, DDLStatementToString) {
     Column* column1 = createTable->add_primarykeys();
     column1->set_columnname("testColumn1");
     
-    ColumnDataInfo* columnDataInfo1 = column1->mutable_columndatainfo();
-    columnDataInfo1->set_scalartype(ColumnDataInfo::STRING);
-    columnDataInfo1->set_length(200);
-    columnDataInfo1->set_lengthtype(ColumnDataInfo::UNBOUND);
-    columnDataInfo1->set_isarray(false);
+    ColumnDataType* columnDataType1 = column1->mutable_columndatatype();
+    columnDataType1->set_scalartype(ColumnDataType::STRING);
+    columnDataType1->set_length(200);
+    columnDataType1->set_lengthtype(ColumnDataType::UNBOUND);
+    columnDataType1->set_isarray(false);
     column1->set_isnotnull(true);
     column1->set_allowcommittimestamp(true);
     column1->set_orientation(Column::ASC);
@@ -54,11 +55,11 @@ TEST(DDLStatementProtoToString, DDLStatementToString) {
     Column* column2 = createTable->add_primarykeys();
     column2->set_columnname("testColumn2");
     
-    ColumnDataInfo* columnDataInfo2 = column2->mutable_columndatainfo();
-    columnDataInfo2->set_scalartype(ColumnDataInfo::BOOL);
-    columnDataInfo2->set_length(2);
-    columnDataInfo2->set_lengthtype(ColumnDataInfo::MAX);
-    columnDataInfo2->set_isarray(true);
+    ColumnDataType* columnDataType2 = column2->mutable_columndatatype();
+    columnDataType2->set_scalartype(ColumnDataType::BOOL);
+    columnDataType2->set_length(2);
+    columnDataType2->set_lengthtype(ColumnDataType::MAX);
+    columnDataType2->set_isarray(true);
     column2->set_isnotnull(false);
     column2->set_allowcommittimestamp(false);
     column2->set_orientation(Column::DESC);
@@ -66,11 +67,11 @@ TEST(DDLStatementProtoToString, DDLStatementToString) {
     Column* column3 = createTable->add_nonprimarykeys();
     column3->set_columnname("testColumn3");
 
-    ColumnDataInfo* columnDataInfo3 = column3->mutable_columndatainfo();
-    columnDataInfo3->set_scalartype(ColumnDataInfo::TIMESTAMP);
-    columnDataInfo3->set_length(-100);
-    columnDataInfo3->set_lengthtype(ColumnDataInfo::BOUND);
-    columnDataInfo3->set_isarray(false);
+    ColumnDataType* columnDataType3 = column3->mutable_columndatatype();
+    columnDataType3->set_scalartype(ColumnDataType::TIMESTAMP);
+    columnDataType3->set_length(-100);
+    columnDataType3->set_lengthtype(ColumnDataType::BOUND);
+    columnDataType3->set_isarray(false);
     column3->set_isnotnull(false);
     column3->set_allowcommittimestamp(true);
 
@@ -78,12 +79,12 @@ TEST(DDLStatementProtoToString, DDLStatementToString) {
     EXPECT_EQ(createTable->nonprimarykeys().size(), 1);
 
     EXPECT_EQ(toString(*statement1), 
-        absl::StrCat("CREATE TABLE testTable ([ { testColumn1 STRING( 200 )",
-        " NOT NULL { OPTIONS ( allow_commit_timestamp = { true } ) } },",
-        "{ testColumn2 ARRAY< BOOL >  { OPTIONS ( allow_commit_timestamp = ",
-        "{ null } ) } },{ testColumn3 TIMESTAMP  { OPTIONS ( ",
-        "allow_commit_timestamp = { true } ) } } ]) PRIMARY KEY ( ",
-        "[testColumn1 [ { ASC } ],testColumn2 [ { DESC } ]] )"));
+        absl::StrCat("CREATE TABLE testTable ( testColumn1 STRING( 200 )",
+        " NOT NULL OPTIONS ( allow_commit_timestamp = true ),",
+        "testColumn2 ARRAY< BOOL >  OPTIONS ( allow_commit_timestamp = ",
+        "null ),testColumn3 TIMESTAMP  OPTIONS ",
+        "( allow_commit_timestamp = true ) ) PRIMARY KEY ( ",
+        "testColumn1 [ { ASC } ],testColumn2 [ { DESC } ] )"));
 }
 
 TEST(DDLStatementProtoToString, CreateTableToString) {
@@ -93,11 +94,11 @@ TEST(DDLStatementProtoToString, CreateTableToString) {
     Column* column1 = createTable.add_primarykeys();
     column1->set_columnname("testColumn1");
     
-    ColumnDataInfo* columnDataInfo1 = column1->mutable_columndatainfo();
-    columnDataInfo1->set_scalartype(ColumnDataInfo::STRING);
-    columnDataInfo1->set_length(200);
-    columnDataInfo1->set_lengthtype(ColumnDataInfo::UNBOUND);
-    columnDataInfo1->set_isarray(false);
+    ColumnDataType* columnDataType1 = column1->mutable_columndatatype();
+    columnDataType1->set_scalartype(ColumnDataType::STRING);
+    columnDataType1->set_length(200);
+    columnDataType1->set_lengthtype(ColumnDataType::UNBOUND);
+    columnDataType1->set_isarray(false);
     column1->set_isnotnull(true);
     column1->set_allowcommittimestamp(true);
     column1->set_orientation(Column::ASC);
@@ -105,11 +106,11 @@ TEST(DDLStatementProtoToString, CreateTableToString) {
     Column* column2 = createTable.add_primarykeys();
     column2->set_columnname("testColumn2");
     
-    ColumnDataInfo* columnDataInfo2 = column2->mutable_columndatainfo();
-    columnDataInfo2->set_scalartype(ColumnDataInfo::BOOL);
-    columnDataInfo2->set_length(2);
-    columnDataInfo2->set_lengthtype(ColumnDataInfo::MAX);
-    columnDataInfo2->set_isarray(true);
+    ColumnDataType* columnDataType2 = column2->mutable_columndatatype();
+    columnDataType2->set_scalartype(ColumnDataType::BOOL);
+    columnDataType2->set_length(2);
+    columnDataType2->set_lengthtype(ColumnDataType::MAX);
+    columnDataType2->set_isarray(true);
     column2->set_isnotnull(false);
     column2->set_allowcommittimestamp(false);
     column2->set_orientation(Column::DESC);
@@ -117,11 +118,11 @@ TEST(DDLStatementProtoToString, CreateTableToString) {
     Column* column3 = createTable.add_nonprimarykeys();
     column3->set_columnname("testColumn3");
 
-    ColumnDataInfo* columnDataInfo3 = column3->mutable_columndatainfo();
-    columnDataInfo3->set_scalartype(ColumnDataInfo::TIMESTAMP);
-    columnDataInfo3->set_length(-100);
-    columnDataInfo3->set_lengthtype(ColumnDataInfo::BOUND);
-    columnDataInfo3->set_isarray(false);
+    ColumnDataType* columnDataType3 = column3->mutable_columndatatype();
+    columnDataType3->set_scalartype(ColumnDataType::TIMESTAMP);
+    columnDataType3->set_length(-100);
+    columnDataType3->set_lengthtype(ColumnDataType::BOUND);
+    columnDataType3->set_isarray(false);
     column3->set_isnotnull(false);
     column3->set_allowcommittimestamp(true);
 
@@ -129,148 +130,204 @@ TEST(DDLStatementProtoToString, CreateTableToString) {
     EXPECT_EQ(createTable.nonprimarykeys().size(), 1);
 
     EXPECT_EQ(toString(createTable), 
-        absl::StrCat("CREATE TABLE testTable ([ { testColumn1 STRING( ",
-        "200 ) NOT NULL { OPTIONS ( allow_commit_timestamp = { true } )",
-        " } },{ testColumn2 ARRAY< BOOL >  { OPTIONS ( allow_commit_timestamp",
-        " = { null } ) } },{ testColumn3 TIMESTAMP  { OPTIONS ( ",
-        "allow_commit_timestamp = { true } ) } } ]) PRIMARY KEY ( ",
-        "[testColumn1 [ { ASC } ],testColumn2 [ { DESC } ]] )"));
+        absl::StrCat("CREATE TABLE testTable ( testColumn1 STRING( ",
+        "200 ) NOT NULL OPTIONS ( allow_commit_timestamp = true )",
+        ",testColumn2 ARRAY< BOOL >  OPTIONS ( allow_commit_timestamp",
+        " = null ),testColumn3 TIMESTAMP  OPTIONS ",
+        "( allow_commit_timestamp = true ) ) PRIMARY KEY ( ",
+        "testColumn1 [ { ASC } ],testColumn2 [ { DESC } ] )"));
+}
+
+TEST(DDLStatementProtoToString, TableColumnsToStringTest) {
+    CreateTable create_table;
+
+    EXPECT_EQ(tableColumnsToString(create_table.primarykeys(), create_table.nonprimarykeys()), "");
+
+    Column* column1 = create_table.add_primarykeys();
+    column1->set_columnname("testColumn1");
+    
+    ColumnDataType* columnDataType1 = column1->mutable_columndatatype();
+    columnDataType1->set_scalartype(ColumnDataType::STRING);
+    columnDataType1->set_length(200);
+    columnDataType1->set_lengthtype(ColumnDataType::UNBOUND);
+    columnDataType1->set_isarray(false);
+    column1->set_isnotnull(true);
+    column1->set_allowcommittimestamp(true);
+
+    EXPECT_EQ(tableColumnsToString(create_table.primarykeys(), create_table.nonprimarykeys()), 
+    "testColumn1 STRING( 200 ) NOT NULL OPTIONS ( allow_commit_timestamp = true )");
+
+    create_table.clear_primarykeys();
+
+    Column* column2 = create_table.add_nonprimarykeys();
+    column2->set_columnname("testColumn2");
+    
+    ColumnDataType* columnDataType2 = column2->mutable_columndatatype();
+    columnDataType2->set_scalartype(ColumnDataType::BOOL);
+    columnDataType2->set_length(2);
+    columnDataType2->set_lengthtype(ColumnDataType::MAX);
+    columnDataType2->set_isarray(true);
+    column2->set_isnotnull(false);
+    column2->set_allowcommittimestamp(false);
+    
+    EXPECT_EQ(tableColumnsToString(create_table.primarykeys(), create_table.nonprimarykeys()), 
+    "testColumn2 ARRAY< BOOL >  OPTIONS ( allow_commit_timestamp = null )");
+
+    Column* column3 = create_table.add_primarykeys();
+    column1->set_columnname("testColumn3");
+
+    ColumnDataType* columnDataType3 = column3->mutable_columndatatype();
+    columnDataType3->set_scalartype(ColumnDataType::STRING);
+    columnDataType3->set_length(200);
+    columnDataType3->set_lengthtype(ColumnDataType::UNBOUND);
+    columnDataType3->set_isarray(false);
+    column3->set_isnotnull(true);
+    column3->set_allowcommittimestamp(true);
+
+    EXPECT_EQ(tableColumnsToString(create_table.primarykeys(), create_table.nonprimarykeys()),
+        absl::StrCat("testColumn3 STRING( 200 ) NOT NULL ", 
+        "OPTIONS ( allow_commit_timestamp = true ),",
+        "testColumn2 ARRAY< BOOL >  OPTIONS",
+        " ( allow_commit_timestamp = null )"));
 }
 
 TEST(DDLStatementProtoToString, ColumnsToString) {
     CreateTable createTable;
 
+    EXPECT_EQ(createTable.primarykeys().size(), 0);
+    EXPECT_EQ(toString(createTable.primarykeys()), "");
+
     Column* column1 = createTable.add_primarykeys();
     column1->set_columnname("testColumn1");
     
-    ColumnDataInfo* columnDataInfo1 = column1->mutable_columndatainfo();
-    columnDataInfo1->set_scalartype(ColumnDataInfo::STRING);
-    columnDataInfo1->set_length(200);
-    columnDataInfo1->set_lengthtype(ColumnDataInfo::UNBOUND);
-    columnDataInfo1->set_isarray(false);
+    ColumnDataType* columnDataType1 = column1->mutable_columndatatype();
+    columnDataType1->set_scalartype(ColumnDataType::STRING);
+    columnDataType1->set_length(200);
+    columnDataType1->set_lengthtype(ColumnDataType::UNBOUND);
+    columnDataType1->set_isarray(false);
     column1->set_isnotnull(true);
     column1->set_allowcommittimestamp(true);
 
     Column* column2 = createTable.add_primarykeys();
     column2->set_columnname("testColumn2");
     
-    ColumnDataInfo* columnDataInfo2 = column2->mutable_columndatainfo();
-    columnDataInfo2->set_scalartype(ColumnDataInfo::BOOL);
-    columnDataInfo2->set_length(2);
-    columnDataInfo2->set_lengthtype(ColumnDataInfo::MAX);
-    columnDataInfo2->set_isarray(true);
+    ColumnDataType* columnDataType2 = column2->mutable_columndatatype();
+    columnDataType2->set_scalartype(ColumnDataType::BOOL);
+    columnDataType2->set_length(2);
+    columnDataType2->set_lengthtype(ColumnDataType::MAX);
+    columnDataType2->set_isarray(true);
     column2->set_isnotnull(false);
     column2->set_allowcommittimestamp(false);
 
     EXPECT_EQ(createTable.primarykeys().size(), 2);
 
     EXPECT_EQ(toString(createTable.primarykeys()), 
-        absl::StrCat("{ testColumn1 STRING( 200 ) NOT NULL ", 
-        "{ OPTIONS ( allow_commit_timestamp = { true } ) } },",
-        "{ testColumn2 ARRAY< BOOL >  { OPTIONS (",
-        " allow_commit_timestamp = { null } ) } }"));
+        absl::StrCat("testColumn1 STRING( 200 ) NOT NULL ", 
+        "OPTIONS ( allow_commit_timestamp = true ),",
+        "testColumn2 ARRAY< BOOL >  OPTIONS",
+        " ( allow_commit_timestamp = null )"));
 }
 
 TEST(DDLStatementProtoToString, ColumnToStringTest) {
     Column column;
     column.set_columnname("testColumn");
     
-    ColumnDataInfo* columnDataInfo = column.mutable_columndatainfo();
+    ColumnDataType* columnDataType = column.mutable_columndatatype();
 
-    EXPECT_EQ(columnDataInfo->has_scalartype(), false);
-    EXPECT_EQ(columnDataInfo->has_length(), false);
-    EXPECT_EQ(columnDataInfo->has_lengthtype(), false);
-    EXPECT_EQ(columnDataInfo->has_isarray(), false);
+    EXPECT_EQ(columnDataType->has_scalartype(), false);
+    EXPECT_EQ(columnDataType->has_length(), false);
+    EXPECT_EQ(columnDataType->has_lengthtype(), false);
+    EXPECT_EQ(columnDataType->has_isarray(), false);
 
-    columnDataInfo->set_scalartype(ColumnDataInfo::STRING);
-    columnDataInfo->set_length(200);
-    columnDataInfo->set_lengthtype(ColumnDataInfo::BOUND);
-    columnDataInfo->set_isarray(false);
+    columnDataType->set_scalartype(ColumnDataType::STRING);
+    columnDataType->set_length(200);
+    columnDataType->set_lengthtype(ColumnDataType::BOUND);
+    columnDataType->set_isarray(false);
 
     column.set_isnotnull(true);
     column.set_allowcommittimestamp(true);
 
-    EXPECT_EQ(toString(column), absl::StrCat("{ testColumn STRING( 201 )",
-    " NOT NULL { OPTIONS ( allow_commit_timestamp = { true } ) } },"));
+    EXPECT_EQ(toString(column), absl::StrCat("testColumn STRING( 201 )",
+    " NOT NULL OPTIONS ( allow_commit_timestamp = true )"));
 }
 
 TEST(DDLStatementProtoToString, ColumnInfoDataToStringTest) {
-    ColumnDataInfo columnDataInfo;
+    ColumnDataType columnDataType;
 
-    EXPECT_EQ(columnDataInfo.has_scalartype(), false);
-    EXPECT_EQ(columnDataInfo.has_length(), false);
-    EXPECT_EQ(columnDataInfo.has_lengthtype(), false);
-    EXPECT_EQ(columnDataInfo.has_isarray(), false);
+    EXPECT_EQ(columnDataType.has_scalartype(), false);
+    EXPECT_EQ(columnDataType.has_length(), false);
+    EXPECT_EQ(columnDataType.has_lengthtype(), false);
+    EXPECT_EQ(columnDataType.has_isarray(), false);
 
-    columnDataInfo.set_scalartype(ColumnDataInfo::STRING);
-    columnDataInfo.set_length(200);
-    columnDataInfo.set_lengthtype(ColumnDataInfo::BOUND);
+    columnDataType.set_scalartype(ColumnDataType::STRING);
+    columnDataType.set_length(200);
+    columnDataType.set_lengthtype(ColumnDataType::BOUND);
 
-    columnDataInfo.set_isarray(false);
-    EXPECT_EQ(toString(columnDataInfo), "STRING( 201 )");  
+    columnDataType.set_isarray(false);
+    EXPECT_EQ(toString(columnDataType), "STRING( 201 )");  
 
-    columnDataInfo.set_isarray(true);
-    EXPECT_EQ(toString(columnDataInfo), "ARRAY< STRING( 201 ) >");  
+    columnDataType.set_isarray(true);
+    EXPECT_EQ(toString(columnDataType), "ARRAY< STRING( 201 ) >");  
 }
 
-TEST(DDLStatementProtoToString, ColumnDataInfoToStringHelperTest) {
-    ColumnDataInfo columnDataInfo;
+TEST(DDLStatementProtoToString, ColumnDataTypeToStringHelperTest) {
+    ColumnDataType columnDataType;
 
-    EXPECT_EQ(columnDataInfo.has_scalartype(), false);
-    EXPECT_EQ(columnDataInfo.has_length(), false);
-    EXPECT_EQ(columnDataInfo.has_lengthtype(), false);
+    EXPECT_EQ(columnDataType.has_scalartype(), false);
+    EXPECT_EQ(columnDataType.has_length(), false);
+    EXPECT_EQ(columnDataType.has_lengthtype(), false);
 
-    columnDataInfo.set_scalartype(ColumnDataInfo::BOOL);
-    columnDataInfo.set_length(-500);
-    columnDataInfo.set_lengthtype(ColumnDataInfo::UNBOUND);
-    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
-        columnDataInfo.lengthtype()), "BOOL");
+    columnDataType.set_scalartype(ColumnDataType::BOOL);
+    columnDataType.set_length(-500);
+    columnDataType.set_lengthtype(ColumnDataType::UNBOUND);
+    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
+        columnDataType.lengthtype()), "BOOL");
 
-    columnDataInfo.set_scalartype(ColumnDataInfo::INT64);
-    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
-        columnDataInfo.lengthtype()), "INT64");
+    columnDataType.set_scalartype(ColumnDataType::INT64);
+    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
+        columnDataType.lengthtype()), "INT64");
     
-    columnDataInfo.set_scalartype(ColumnDataInfo::FLOAT64);
-    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
-        columnDataInfo.lengthtype()), "FLOAT64");
+    columnDataType.set_scalartype(ColumnDataType::FLOAT64);
+    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
+        columnDataType.lengthtype()), "FLOAT64");
 
-    columnDataInfo.set_scalartype(ColumnDataInfo::DATE);
-    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
-        columnDataInfo.lengthtype()), "DATE");
+    columnDataType.set_scalartype(ColumnDataType::DATE);
+    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
+        columnDataType.lengthtype()), "DATE");
 
-    columnDataInfo.set_scalartype(ColumnDataInfo::TIMESTAMP);
-    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
-        columnDataInfo.lengthtype()), "TIMESTAMP");
+    columnDataType.set_scalartype(ColumnDataType::TIMESTAMP);
+    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
+        columnDataType.lengthtype()), "TIMESTAMP");
 
-    columnDataInfo.set_scalartype(ColumnDataInfo::STRING);
-    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
-        columnDataInfo.lengthtype()), "STRING( -500 )");
-    columnDataInfo.set_lengthtype(ColumnDataInfo::MAX);
-    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
-        columnDataInfo.lengthtype()), "STRING( MAX )");
-    columnDataInfo.set_lengthtype(ColumnDataInfo::BOUND);
-    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
-        columnDataInfo.lengthtype()), "STRING( 501 )");
+    columnDataType.set_scalartype(ColumnDataType::STRING);
+    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
+        columnDataType.lengthtype()), "STRING( -500 )");
+    columnDataType.set_lengthtype(ColumnDataType::MAX);
+    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
+        columnDataType.lengthtype()), "STRING( MAX )");
+    columnDataType.set_lengthtype(ColumnDataType::BOUND);
+    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
+        columnDataType.lengthtype()), "STRING( 501 )");
     // test that the max wraps back to 1
-    columnDataInfo.set_length(2621440);
-    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
-        columnDataInfo.lengthtype()), "STRING( 1 )");
+    columnDataType.set_length(2621440);
+    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
+        columnDataType.lengthtype()), "STRING( 1 )");
 
-    columnDataInfo.set_length(-500);
-    columnDataInfo.set_lengthtype(ColumnDataInfo::UNBOUND);
-    columnDataInfo.set_scalartype(ColumnDataInfo::BYTES);
-    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
-        columnDataInfo.lengthtype()), "BYTES( -500 )");
-    columnDataInfo.set_lengthtype(ColumnDataInfo::MAX);
-    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
-        columnDataInfo.lengthtype()), "BYTES( MAX )");
-    columnDataInfo.set_lengthtype(ColumnDataInfo::BOUND);
-    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
-        columnDataInfo.lengthtype()), "BYTES( 501 )");
+    columnDataType.set_length(-500);
+    columnDataType.set_lengthtype(ColumnDataType::UNBOUND);
+    columnDataType.set_scalartype(ColumnDataType::BYTES);
+    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
+        columnDataType.lengthtype()), "BYTES( -500 )");
+    columnDataType.set_lengthtype(ColumnDataType::MAX);
+    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
+        columnDataType.lengthtype()), "BYTES( MAX )");
+    columnDataType.set_lengthtype(ColumnDataType::BOUND);
+    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
+        columnDataType.lengthtype()), "BYTES( 501 )");
     // test that the max wraps back to 1
-    columnDataInfo.set_length(10485760);
-    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
-        columnDataInfo.lengthtype()), "BYTES( 1 )");
+    columnDataType.set_length(10485760);
+    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
+        columnDataType.lengthtype()), "BYTES( 1 )");
 }
 
 TEST(DDLStatementProtoToString, IsColumnNotNullToStringTest) {
@@ -279,8 +336,8 @@ TEST(DDLStatementProtoToString, IsColumnNotNullToStringTest) {
 }
 
 TEST(DDLStatementProtoToString, ColumnOptionsToStringTest) {
-    EXPECT_EQ(columnOptionsToString(false), "{ OPTIONS ( allow_commit_timestamp = { null } ) }");
-    EXPECT_EQ(columnOptionsToString(true), "{ OPTIONS ( allow_commit_timestamp = { true } ) }");
+    EXPECT_EQ(columnOptionsToString(false), "OPTIONS ( allow_commit_timestamp = null )");
+    EXPECT_EQ(columnOptionsToString(true), "OPTIONS ( allow_commit_timestamp = true )");
 }
 
 TEST(DDLStatementProtoToString, ToPrimaryKeysTest) {

--- a/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
+++ b/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
@@ -291,18 +291,18 @@ TEST(DDLStatementProtoToString, ToPrimaryKeysTest) {
     EXPECT_EQ(column1->has_orientation(), false);
 
     column1->set_orientation(Column::ASC);
-    column1->set_columnname("testName1");
+    column1->set_columnname("testColumn1");
 
     Column* column2 = createTable.add_primarykeys();
     EXPECT_EQ(column2->has_columnname(), false);
     EXPECT_EQ(column2->has_orientation(), false);
 
     column2->set_orientation(Column::DESC);
-    column2->set_columnname("testName2");
+    column2->set_columnname("testColumn2");
 
     EXPECT_EQ(createTable.primarykeys().size(), 2);
 
-    EXPECT_EQ(toPrimaryKeys(createTable.primarykeys()), "testName1 [ { ASC } ],testName2 [ { DESC } ]");
+    EXPECT_EQ(toPrimaryKeys(createTable.primarykeys()), "testColumn1 [ { ASC } ],testColumn2 [ { DESC } ]");
 }
 
 TEST(DDLStatementProtoToString, ColumnToPrimaryKeyTest) {
@@ -311,9 +311,9 @@ TEST(DDLStatementProtoToString, ColumnToPrimaryKeyTest) {
     EXPECT_EQ(column.has_orientation(), false);
 
     column.set_orientation(Column::ASC);
-    column.set_columnname("testName");
+    column.set_columnname("testColumn");
 
-    EXPECT_EQ(columnToPrimaryKey(column), "testName [ { ASC } ],");
+    EXPECT_EQ(columnToPrimaryKey(column), "testColumn [ { ASC } ],");
 }
 
 TEST(DDLStatementProtoToString, ColumnOrientationTest) {

--- a/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
+++ b/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
@@ -32,6 +32,7 @@ using spanner_ddl::CreateTable;
 using spanner_ddl::Column;
 using spanner_ddl::ColumnDataType;
 
+//TODO: add test that creates a table in the emulator using a protobuf
 //TODO: add more to this test as more APIs are added
 TEST(DDLStatementProtoToString, DDLStatementToString) {
     SpannerFuzzingStatements statements;

--- a/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
+++ b/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
@@ -370,7 +370,7 @@ TEST(DDLStatementProtoToString, ColumnToPrimaryKeyTest) {
     column.set_orientation(Column::ASC);
     column.set_columnname("testColumn");
 
-    EXPECT_EQ(columnToPrimaryKey(column), "testColumn ASC,");
+    EXPECT_EQ(columnToPrimaryKey(column), "testColumn ASC");
 }
 
 TEST(DDLStatementProtoToString, ColumnOrientationTest) {

--- a/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
+++ b/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
@@ -84,7 +84,7 @@ TEST(DDLStatementProtoToString, DDLStatementToString) {
         "testColumn2 ARRAY< BOOL >  OPTIONS ( allow_commit_timestamp = ",
         "null ),testColumn3 TIMESTAMP  OPTIONS ",
         "( allow_commit_timestamp = true ) ) PRIMARY KEY ( ",
-        "testColumn1 [ { ASC } ],testColumn2 [ { DESC } ] )"));
+        "testColumn1 ASC,testColumn2 DESC )"));
 }
 
 TEST(DDLStatementProtoToString, CreateTableToString) {
@@ -135,7 +135,7 @@ TEST(DDLStatementProtoToString, CreateTableToString) {
         ",testColumn2 ARRAY< BOOL >  OPTIONS ( allow_commit_timestamp",
         " = null ),testColumn3 TIMESTAMP  OPTIONS ",
         "( allow_commit_timestamp = true ) ) PRIMARY KEY ( ",
-        "testColumn1 [ { ASC } ],testColumn2 [ { DESC } ] )"));
+        "testColumn1 ASC,testColumn2 DESC )"));
 }
 
 TEST(DDLStatementProtoToString, TableColumnsToStringTest) {
@@ -359,7 +359,7 @@ TEST(DDLStatementProtoToString, ToPrimaryKeysTest) {
 
     EXPECT_EQ(createTable.primarykeys().size(), 2);
 
-    EXPECT_EQ(toPrimaryKeys(createTable.primarykeys()), "testColumn1 [ { ASC } ],testColumn2 [ { DESC } ]");
+    EXPECT_EQ(toPrimaryKeys(createTable.primarykeys()), "testColumn1 ASC,testColumn2 DESC");
 }
 
 TEST(DDLStatementProtoToString, ColumnToPrimaryKeyTest) {
@@ -370,7 +370,7 @@ TEST(DDLStatementProtoToString, ColumnToPrimaryKeyTest) {
     column.set_orientation(Column::ASC);
     column.set_columnname("testColumn");
 
-    EXPECT_EQ(columnToPrimaryKey(column), "testColumn [ { ASC } ],");
+    EXPECT_EQ(columnToPrimaryKey(column), "testColumn ASC,");
 }
 
 TEST(DDLStatementProtoToString, ColumnOrientationTest) {

--- a/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
+++ b/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
@@ -79,12 +79,14 @@ TEST(DDLStatementProtoToString, DDLStatementToString) {
     EXPECT_EQ(create_table->nonprimarykeys().size(), 1);
 
     EXPECT_EQ(toString(*statement1), 
-        absl::StrCat("CREATE TABLE testTable ( testColumn1 STRING( 200 )",
-        " NOT NULL OPTIONS ( allow_commit_timestamp = true ),",
-        "testColumn2 ARRAY< BOOL >  OPTIONS ( allow_commit_timestamp = ",
-        "null ),testColumn3 TIMESTAMP  OPTIONS ",
-        "( allow_commit_timestamp = true ) ) PRIMARY KEY ( ",
-        "testColumn1 ASC,testColumn2 DESC )"));
+        "CREATE TABLE testTable ( "
+        "testColumn1 STRING( 200 ) "
+        "NOT NULL OPTIONS ( allow_commit_timestamp = true ),"
+        "testColumn2 ARRAY< BOOL >  "
+        "OPTIONS ( allow_commit_timestamp = null ),"
+        "testColumn3 TIMESTAMP  "
+        "OPTIONS ( allow_commit_timestamp = true ) ) "
+        "PRIMARY KEY ( testColumn1 ASC,testColumn2 DESC )");
 }
 
 TEST(DDLStatementProtoToString, CreateTableToString) {
@@ -130,18 +132,22 @@ TEST(DDLStatementProtoToString, CreateTableToString) {
     EXPECT_EQ(create_table.nonprimarykeys().size(), 1);
 
     EXPECT_EQ(toString(create_table), 
-        absl::StrCat("CREATE TABLE testTable ( testColumn1 STRING( ",
-        "200 ) NOT NULL OPTIONS ( allow_commit_timestamp = true )",
-        ",testColumn2 ARRAY< BOOL >  OPTIONS ( allow_commit_timestamp",
-        " = null ),testColumn3 TIMESTAMP  OPTIONS ",
-        "( allow_commit_timestamp = true ) ) PRIMARY KEY ( ",
-        "testColumn1 ASC,testColumn2 DESC )"));
+        "CREATE TABLE testTable ( "
+        "testColumn1 STRING( 200 ) "
+        "NOT NULL OPTIONS ( allow_commit_timestamp = true ),"
+        "testColumn2 ARRAY< BOOL >  "
+        "OPTIONS ( allow_commit_timestamp = null ),"
+        "testColumn3 TIMESTAMP  "
+        "OPTIONS ( allow_commit_timestamp = true ) ) "
+        "PRIMARY KEY ( testColumn1 ASC,testColumn2 DESC )"
+    );
 }
 
 TEST(DDLStatementProtoToString, TableColumnsToStringTest) {
     CreateTable create_table;
 
-    EXPECT_EQ(tableColumnsToString(create_table.primarykeys(), create_table.nonprimarykeys()), "");
+    EXPECT_EQ(tableColumnsToString(create_table.primarykeys(), 
+        create_table.nonprimarykeys()), "");
 
     Column* column1 = create_table.add_primarykeys();
     column1->set_columnname("testColumn1");
@@ -154,8 +160,11 @@ TEST(DDLStatementProtoToString, TableColumnsToStringTest) {
     column1->set_isnotnull(true);
     column1->set_allowcommittimestamp(true);
 
-    EXPECT_EQ(tableColumnsToString(create_table.primarykeys(), create_table.nonprimarykeys()), 
-    "testColumn1 STRING( 200 ) NOT NULL OPTIONS ( allow_commit_timestamp = true )");
+    EXPECT_EQ(tableColumnsToString(create_table.primarykeys(), 
+        create_table.nonprimarykeys()), 
+        "testColumn1 STRING( 200 ) NOT NULL "
+        "OPTIONS ( allow_commit_timestamp = true )"
+        );
 
     create_table.clear_primarykeys();
 
@@ -170,8 +179,11 @@ TEST(DDLStatementProtoToString, TableColumnsToStringTest) {
     column2->set_isnotnull(false);
     column2->set_allowcommittimestamp(false);
     
-    EXPECT_EQ(tableColumnsToString(create_table.primarykeys(), create_table.nonprimarykeys()), 
-    "testColumn2 ARRAY< BOOL >  OPTIONS ( allow_commit_timestamp = null )");
+    EXPECT_EQ(tableColumnsToString(create_table.primarykeys(), 
+        create_table.nonprimarykeys()), 
+        "testColumn2 ARRAY< BOOL >  "
+        "OPTIONS ( allow_commit_timestamp = null )"
+    );
 
     Column* column3 = create_table.add_primarykeys();
     column1->set_columnname("testColumn3");
@@ -184,11 +196,13 @@ TEST(DDLStatementProtoToString, TableColumnsToStringTest) {
     column3->set_isnotnull(true);
     column3->set_allowcommittimestamp(true);
 
-    EXPECT_EQ(tableColumnsToString(create_table.primarykeys(), create_table.nonprimarykeys()),
-        absl::StrCat("testColumn3 STRING( 200 ) NOT NULL ", 
-        "OPTIONS ( allow_commit_timestamp = true ),",
-        "testColumn2 ARRAY< BOOL >  OPTIONS",
-        " ( allow_commit_timestamp = null )"));
+    EXPECT_EQ(tableColumnsToString(create_table.primarykeys(), 
+        create_table.nonprimarykeys()),
+        "testColumn3 STRING( 200 ) NOT NULL "
+        "OPTIONS ( allow_commit_timestamp = true ),"
+        "testColumn2 ARRAY< BOOL >  "
+        "OPTIONS ( allow_commit_timestamp = null )"
+        );
 }
 
 TEST(DDLStatementProtoToString, ColumnsToString) {
@@ -222,10 +236,11 @@ TEST(DDLStatementProtoToString, ColumnsToString) {
     EXPECT_EQ(create_table.primarykeys().size(), 2);
 
     EXPECT_EQ(toString(create_table.primarykeys()), 
-        absl::StrCat("testColumn1 STRING( 200 ) NOT NULL ", 
-        "OPTIONS ( allow_commit_timestamp = true ),",
-        "testColumn2 ARRAY< BOOL >  OPTIONS",
-        " ( allow_commit_timestamp = null )"));
+        "testColumn1 STRING( 200 ) NOT NULL "
+        "OPTIONS ( allow_commit_timestamp = true ),"
+        "testColumn2 ARRAY< BOOL >  "
+        "OPTIONS ( allow_commit_timestamp = null )"
+    );
 }
 
 TEST(DDLStatementProtoToString, ColumnToStringTest) {
@@ -247,8 +262,10 @@ TEST(DDLStatementProtoToString, ColumnToStringTest) {
     column.set_isnotnull(true);
     column.set_allowcommittimestamp(true);
 
-    EXPECT_EQ(toString(column), absl::StrCat("testColumn STRING( 201 )",
-    " NOT NULL OPTIONS ( allow_commit_timestamp = true )"));
+    EXPECT_EQ(toString(column), 
+        "testColumn STRING( 201 ) NOT NULL "
+        "OPTIONS ( allow_commit_timestamp = true )"
+    );
 }
 
 TEST(DDLStatementProtoToString, ColumnInfoDataToStringTest) {
@@ -280,54 +297,120 @@ TEST(DDLStatementProtoToString, ColumnDataTypeToStringHelperTest) {
     column_data_type.set_scalartype(ColumnDataType::BOOL);
     column_data_type.set_length(-500);
     column_data_type.set_lengthtype(ColumnDataType::UNBOUND);
-    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
-        column_data_type.lengthtype()), "BOOL");
+    EXPECT_EQ(
+        toString(
+            column_data_type.scalartype(), 
+            column_data_type.length(), 
+            column_data_type.lengthtype()
+        ), 
+        "BOOL"
+    );
 
     column_data_type.set_scalartype(ColumnDataType::INT64);
-    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
-        column_data_type.lengthtype()), "INT64");
+    EXPECT_EQ(
+        toString(
+            column_data_type.scalartype(), 
+            column_data_type.length(), 
+            column_data_type.lengthtype()), 
+        "INT64"
+    );
     
     column_data_type.set_scalartype(ColumnDataType::FLOAT64);
-    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
-        column_data_type.lengthtype()), "FLOAT64");
+    EXPECT_EQ(
+        toString(
+            column_data_type.scalartype(), 
+            column_data_type.length(), 
+            column_data_type.lengthtype()), 
+        "FLOAT64"
+    );
 
     column_data_type.set_scalartype(ColumnDataType::DATE);
-    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
-        column_data_type.lengthtype()), "DATE");
+    EXPECT_EQ(
+        toString(
+            column_data_type.scalartype(), 
+            column_data_type.length(), 
+            column_data_type.lengthtype()), 
+        "DATE"
+    );
 
     column_data_type.set_scalartype(ColumnDataType::TIMESTAMP);
-    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
-        column_data_type.lengthtype()), "TIMESTAMP");
+    EXPECT_EQ(
+        toString(
+            column_data_type.scalartype(), 
+            column_data_type.length(), 
+            column_data_type.lengthtype()), 
+        "TIMESTAMP"
+    );
 
     column_data_type.set_scalartype(ColumnDataType::STRING);
-    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
-        column_data_type.lengthtype()), "STRING( -500 )");
+    EXPECT_EQ(
+        toString(
+            column_data_type.scalartype(), 
+            column_data_type.length(), 
+            column_data_type.lengthtype()), 
+        "STRING( -500 )"
+    );
     column_data_type.set_lengthtype(ColumnDataType::MAX);
-    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
-        column_data_type.lengthtype()), "STRING( MAX )");
+    EXPECT_EQ(
+        toString(
+            column_data_type.scalartype(), 
+            column_data_type.length(), 
+            column_data_type.lengthtype()), 
+        "STRING( MAX )"
+    );
     column_data_type.set_lengthtype(ColumnDataType::BOUND);
-    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
-        column_data_type.lengthtype()), "STRING( 501 )");
+    EXPECT_EQ(
+        toString(
+            column_data_type.scalartype(), 
+            column_data_type.length(), 
+            column_data_type.lengthtype()), 
+        "STRING( 501 )"
+    );
     // test that the max wraps back to 1
     column_data_type.set_length(2621440);
-    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
-        column_data_type.lengthtype()), "STRING( 1 )");
+    EXPECT_EQ(
+        toString(
+            column_data_type.scalartype(), 
+            column_data_type.length(), 
+            column_data_type.lengthtype()), 
+        "STRING( 1 )"
+    );
 
     column_data_type.set_length(-500);
     column_data_type.set_lengthtype(ColumnDataType::UNBOUND);
     column_data_type.set_scalartype(ColumnDataType::BYTES);
-    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
-        column_data_type.lengthtype()), "BYTES( -500 )");
+    EXPECT_EQ(
+        toString(
+            column_data_type.scalartype(), 
+            column_data_type.length(), 
+            column_data_type.lengthtype()), 
+        "BYTES( -500 )"
+    );
     column_data_type.set_lengthtype(ColumnDataType::MAX);
-    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
-        column_data_type.lengthtype()), "BYTES( MAX )");
+    EXPECT_EQ(
+        toString(
+            column_data_type.scalartype(), 
+            column_data_type.length(), 
+            column_data_type.lengthtype()), 
+        "BYTES( MAX )"
+    );
     column_data_type.set_lengthtype(ColumnDataType::BOUND);
-    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
-        column_data_type.lengthtype()), "BYTES( 501 )");
+    EXPECT_EQ(
+        toString(
+            column_data_type.scalartype(), 
+            column_data_type.length(), 
+            column_data_type.lengthtype()), 
+        "BYTES( 501 )"
+    );
     // test that the max wraps back to 1
     column_data_type.set_length(10485760);
-    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
-        column_data_type.lengthtype()), "BYTES( 1 )");
+    EXPECT_EQ(
+        toString(
+            column_data_type.scalartype(), 
+            column_data_type.length(), 
+            column_data_type.lengthtype()), 
+        "BYTES( 1 )"
+    );
 }
 
 TEST(DDLStatementProtoToString, IsColumnNotNullToStringTest) {
@@ -336,8 +419,14 @@ TEST(DDLStatementProtoToString, IsColumnNotNullToStringTest) {
 }
 
 TEST(DDLStatementProtoToString, ColumnOptionsToStringTest) {
-    EXPECT_EQ(columnOptionsToString(false), "OPTIONS ( allow_commit_timestamp = null )");
-    EXPECT_EQ(columnOptionsToString(true), "OPTIONS ( allow_commit_timestamp = true )");
+    EXPECT_EQ(
+        columnOptionsToString(false), 
+        "OPTIONS ( allow_commit_timestamp = null )"
+    );
+    EXPECT_EQ(
+        columnOptionsToString(true), 
+        "OPTIONS ( allow_commit_timestamp = true )"
+    );
 }
 
 TEST(DDLStatementProtoToString, ToPrimaryKeysTest) {
@@ -359,7 +448,9 @@ TEST(DDLStatementProtoToString, ToPrimaryKeysTest) {
 
     EXPECT_EQ(create_table.primarykeys().size(), 2);
 
-    EXPECT_EQ(toPrimaryKeys(create_table.primarykeys()), "testColumn1 ASC,testColumn2 DESC");
+    EXPECT_EQ(
+        toPrimaryKeys(create_table.primarykeys()), 
+        "testColumn1 ASC,testColumn2 DESC");
 }
 
 TEST(DDLStatementProtoToString, ColumnToPrimaryKeyTest) {

--- a/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
+++ b/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
@@ -128,7 +128,6 @@ TEST(DDLStatementProtoToString, CreateTableToString) {
     EXPECT_EQ(createTable.primarykeys().size(), 2);
     EXPECT_EQ(createTable.nonprimarykeys().size(), 1);
 
-
     EXPECT_EQ(toString(createTable), 
         absl::StrCat("CREATE TABLE testTable ([ { testColumn1 STRING( ",
         "200 ) NOT NULL { OPTIONS ( allow_commit_timestamp = { true } )",
@@ -193,7 +192,6 @@ TEST(DDLStatementProtoToString, ColumnToStringTest) {
 
     EXPECT_EQ(toString(column), absl::StrCat("{ testColumn STRING( 201 )",
     " NOT NULL { OPTIONS ( allow_commit_timestamp = { true } ) } },"));
-
 }
 
 TEST(DDLStatementProtoToString, ColumnInfoDataToStringTest) {
@@ -213,7 +211,6 @@ TEST(DDLStatementProtoToString, ColumnInfoDataToStringTest) {
 
     columnDataInfo.set_isarray(true);
     EXPECT_EQ(toString(columnDataInfo), "ARRAY< STRING( 201 ) >");  
-
 }
 
 TEST(DDLStatementProtoToString, ColumnDataInfoToStringHelperTest) {
@@ -281,40 +278,9 @@ TEST(DDLStatementProtoToString, IsColumnNotNullToStringTest) {
     EXPECT_EQ(isColumnNotNullToString(false), "");
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-TEST(DDLStatementProtoToString, ColumnOrientationTest) {
-    Column column;
-    EXPECT_EQ(column.has_orientation(), false);
-
-    column.set_orientation(Column::ASC);
-    EXPECT_EQ(toString(column.orientation()), "ASC");
-
-    column.set_orientation(Column::DESC);
-    EXPECT_EQ(toString(column.orientation()), "DESC");
-}
-
-TEST(DDLStatementProtoToString, ColumnToPrimaryKeyTest) {
-    Column column;
-    EXPECT_EQ(column.has_columnname(), false);
-    EXPECT_EQ(column.has_orientation(), false);
-
-    column.set_orientation(Column::ASC);
-    column.set_columnname("testName");
-
-    EXPECT_EQ(columnToPrimaryKey(column), "testName [ { ASC } ],");
+TEST(DDLStatementProtoToString, ColumnOptionsToStringTest) {
+    EXPECT_EQ(columnOptionsToString(false), "{ OPTIONS ( allow_commit_timestamp = { null } ) }");
+    EXPECT_EQ(columnOptionsToString(true), "{ OPTIONS ( allow_commit_timestamp = { true } ) }");
 }
 
 TEST(DDLStatementProtoToString, ToPrimaryKeysTest) {
@@ -339,11 +305,24 @@ TEST(DDLStatementProtoToString, ToPrimaryKeysTest) {
     EXPECT_EQ(toPrimaryKeys(createTable.primarykeys()), "testName1 [ { ASC } ],testName2 [ { DESC } ]");
 }
 
-TEST(DDLStatementProtoToString, ColumnOptionsToStringTest) {
-    EXPECT_EQ(columnOptionsToString(false), "{ OPTIONS ( allow_commit_timestamp = { null } ) }");
-    EXPECT_EQ(columnOptionsToString(true), "{ OPTIONS ( allow_commit_timestamp = { true } ) }");
+TEST(DDLStatementProtoToString, ColumnToPrimaryKeyTest) {
+    Column column;
+    EXPECT_EQ(column.has_columnname(), false);
+    EXPECT_EQ(column.has_orientation(), false);
+
+    column.set_orientation(Column::ASC);
+    column.set_columnname("testName");
+
+    EXPECT_EQ(columnToPrimaryKey(column), "testName [ { ASC } ],");
 }
 
+TEST(DDLStatementProtoToString, ColumnOrientationTest) {
+    Column column;
+    EXPECT_EQ(column.has_orientation(), false);
 
+    column.set_orientation(Column::ASC);
+    EXPECT_EQ(toString(column.orientation()), "ASC");
 
-
+    column.set_orientation(Column::DESC);
+    EXPECT_EQ(toString(column.orientation()), "DESC");
+}

--- a/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
+++ b/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
@@ -37,46 +37,46 @@ TEST(DDLStatementProtoToString, DDLStatementToString) {
     SpannerFuzzingStatements statements;
     SpannerDDLStatement* statement1 = statements.add_statements();
 
-    CreateTable* createTable = statement1->mutable_createtable();
-    createTable->set_tablename("testTable");
+    CreateTable* create_table = statement1->mutable_createtable();
+    create_table->set_tablename("testTable");
 
-    Column* column1 = createTable->add_primarykeys();
+    Column* column1 = create_table->add_primarykeys();
     column1->set_columnname("testColumn1");
     
-    ColumnDataType* columnDataType1 = column1->mutable_columndatatype();
-    columnDataType1->set_scalartype(ColumnDataType::STRING);
-    columnDataType1->set_length(200);
-    columnDataType1->set_lengthtype(ColumnDataType::UNBOUND);
-    columnDataType1->set_isarray(false);
+    ColumnDataType* column_data_type1 = column1->mutable_columndatatype();
+    column_data_type1->set_scalartype(ColumnDataType::STRING);
+    column_data_type1->set_length(200);
+    column_data_type1->set_lengthtype(ColumnDataType::UNBOUND);
+    column_data_type1->set_isarray(false);
     column1->set_isnotnull(true);
     column1->set_allowcommittimestamp(true);
     column1->set_orientation(Column::ASC);
 
-    Column* column2 = createTable->add_primarykeys();
+    Column* column2 = create_table->add_primarykeys();
     column2->set_columnname("testColumn2");
     
-    ColumnDataType* columnDataType2 = column2->mutable_columndatatype();
-    columnDataType2->set_scalartype(ColumnDataType::BOOL);
-    columnDataType2->set_length(2);
-    columnDataType2->set_lengthtype(ColumnDataType::MAX);
-    columnDataType2->set_isarray(true);
+    ColumnDataType* column_data_type2 = column2->mutable_columndatatype();
+    column_data_type2->set_scalartype(ColumnDataType::BOOL);
+    column_data_type2->set_length(2);
+    column_data_type2->set_lengthtype(ColumnDataType::MAX);
+    column_data_type2->set_isarray(true);
     column2->set_isnotnull(false);
     column2->set_allowcommittimestamp(false);
     column2->set_orientation(Column::DESC);
 
-    Column* column3 = createTable->add_nonprimarykeys();
+    Column* column3 = create_table->add_nonprimarykeys();
     column3->set_columnname("testColumn3");
 
-    ColumnDataType* columnDataType3 = column3->mutable_columndatatype();
-    columnDataType3->set_scalartype(ColumnDataType::TIMESTAMP);
-    columnDataType3->set_length(-100);
-    columnDataType3->set_lengthtype(ColumnDataType::BOUND);
-    columnDataType3->set_isarray(false);
+    ColumnDataType* column_data_type3 = column3->mutable_columndatatype();
+    column_data_type3->set_scalartype(ColumnDataType::TIMESTAMP);
+    column_data_type3->set_length(-100);
+    column_data_type3->set_lengthtype(ColumnDataType::BOUND);
+    column_data_type3->set_isarray(false);
     column3->set_isnotnull(false);
     column3->set_allowcommittimestamp(true);
 
-    EXPECT_EQ(createTable->primarykeys().size(), 2);
-    EXPECT_EQ(createTable->nonprimarykeys().size(), 1);
+    EXPECT_EQ(create_table->primarykeys().size(), 2);
+    EXPECT_EQ(create_table->nonprimarykeys().size(), 1);
 
     EXPECT_EQ(toString(*statement1), 
         absl::StrCat("CREATE TABLE testTable ( testColumn1 STRING( 200 )",
@@ -88,48 +88,48 @@ TEST(DDLStatementProtoToString, DDLStatementToString) {
 }
 
 TEST(DDLStatementProtoToString, CreateTableToString) {
-    CreateTable createTable;
-    createTable.set_tablename("testTable");
+    CreateTable create_table;
+    create_table.set_tablename("testTable");
 
-    Column* column1 = createTable.add_primarykeys();
+    Column* column1 = create_table.add_primarykeys();
     column1->set_columnname("testColumn1");
     
-    ColumnDataType* columnDataType1 = column1->mutable_columndatatype();
-    columnDataType1->set_scalartype(ColumnDataType::STRING);
-    columnDataType1->set_length(200);
-    columnDataType1->set_lengthtype(ColumnDataType::UNBOUND);
-    columnDataType1->set_isarray(false);
+    ColumnDataType* column_data_type1 = column1->mutable_columndatatype();
+    column_data_type1->set_scalartype(ColumnDataType::STRING);
+    column_data_type1->set_length(200);
+    column_data_type1->set_lengthtype(ColumnDataType::UNBOUND);
+    column_data_type1->set_isarray(false);
     column1->set_isnotnull(true);
     column1->set_allowcommittimestamp(true);
     column1->set_orientation(Column::ASC);
 
-    Column* column2 = createTable.add_primarykeys();
+    Column* column2 = create_table.add_primarykeys();
     column2->set_columnname("testColumn2");
     
-    ColumnDataType* columnDataType2 = column2->mutable_columndatatype();
-    columnDataType2->set_scalartype(ColumnDataType::BOOL);
-    columnDataType2->set_length(2);
-    columnDataType2->set_lengthtype(ColumnDataType::MAX);
-    columnDataType2->set_isarray(true);
+    ColumnDataType* column_data_type2 = column2->mutable_columndatatype();
+    column_data_type2->set_scalartype(ColumnDataType::BOOL);
+    column_data_type2->set_length(2);
+    column_data_type2->set_lengthtype(ColumnDataType::MAX);
+    column_data_type2->set_isarray(true);
     column2->set_isnotnull(false);
     column2->set_allowcommittimestamp(false);
     column2->set_orientation(Column::DESC);
 
-    Column* column3 = createTable.add_nonprimarykeys();
+    Column* column3 = create_table.add_nonprimarykeys();
     column3->set_columnname("testColumn3");
 
-    ColumnDataType* columnDataType3 = column3->mutable_columndatatype();
-    columnDataType3->set_scalartype(ColumnDataType::TIMESTAMP);
-    columnDataType3->set_length(-100);
-    columnDataType3->set_lengthtype(ColumnDataType::BOUND);
-    columnDataType3->set_isarray(false);
+    ColumnDataType* column_data_type3 = column3->mutable_columndatatype();
+    column_data_type3->set_scalartype(ColumnDataType::TIMESTAMP);
+    column_data_type3->set_length(-100);
+    column_data_type3->set_lengthtype(ColumnDataType::BOUND);
+    column_data_type3->set_isarray(false);
     column3->set_isnotnull(false);
     column3->set_allowcommittimestamp(true);
 
-    EXPECT_EQ(createTable.primarykeys().size(), 2);
-    EXPECT_EQ(createTable.nonprimarykeys().size(), 1);
+    EXPECT_EQ(create_table.primarykeys().size(), 2);
+    EXPECT_EQ(create_table.nonprimarykeys().size(), 1);
 
-    EXPECT_EQ(toString(createTable), 
+    EXPECT_EQ(toString(create_table), 
         absl::StrCat("CREATE TABLE testTable ( testColumn1 STRING( ",
         "200 ) NOT NULL OPTIONS ( allow_commit_timestamp = true )",
         ",testColumn2 ARRAY< BOOL >  OPTIONS ( allow_commit_timestamp",
@@ -146,11 +146,11 @@ TEST(DDLStatementProtoToString, TableColumnsToStringTest) {
     Column* column1 = create_table.add_primarykeys();
     column1->set_columnname("testColumn1");
     
-    ColumnDataType* columnDataType1 = column1->mutable_columndatatype();
-    columnDataType1->set_scalartype(ColumnDataType::STRING);
-    columnDataType1->set_length(200);
-    columnDataType1->set_lengthtype(ColumnDataType::UNBOUND);
-    columnDataType1->set_isarray(false);
+    ColumnDataType* column_data_type1 = column1->mutable_columndatatype();
+    column_data_type1->set_scalartype(ColumnDataType::STRING);
+    column_data_type1->set_length(200);
+    column_data_type1->set_lengthtype(ColumnDataType::UNBOUND);
+    column_data_type1->set_isarray(false);
     column1->set_isnotnull(true);
     column1->set_allowcommittimestamp(true);
 
@@ -162,11 +162,11 @@ TEST(DDLStatementProtoToString, TableColumnsToStringTest) {
     Column* column2 = create_table.add_nonprimarykeys();
     column2->set_columnname("testColumn2");
     
-    ColumnDataType* columnDataType2 = column2->mutable_columndatatype();
-    columnDataType2->set_scalartype(ColumnDataType::BOOL);
-    columnDataType2->set_length(2);
-    columnDataType2->set_lengthtype(ColumnDataType::MAX);
-    columnDataType2->set_isarray(true);
+    ColumnDataType* column_data_type2 = column2->mutable_columndatatype();
+    column_data_type2->set_scalartype(ColumnDataType::BOOL);
+    column_data_type2->set_length(2);
+    column_data_type2->set_lengthtype(ColumnDataType::MAX);
+    column_data_type2->set_isarray(true);
     column2->set_isnotnull(false);
     column2->set_allowcommittimestamp(false);
     
@@ -176,11 +176,11 @@ TEST(DDLStatementProtoToString, TableColumnsToStringTest) {
     Column* column3 = create_table.add_primarykeys();
     column1->set_columnname("testColumn3");
 
-    ColumnDataType* columnDataType3 = column3->mutable_columndatatype();
-    columnDataType3->set_scalartype(ColumnDataType::STRING);
-    columnDataType3->set_length(200);
-    columnDataType3->set_lengthtype(ColumnDataType::UNBOUND);
-    columnDataType3->set_isarray(false);
+    ColumnDataType* column_data_type3 = column3->mutable_columndatatype();
+    column_data_type3->set_scalartype(ColumnDataType::STRING);
+    column_data_type3->set_length(200);
+    column_data_type3->set_lengthtype(ColumnDataType::UNBOUND);
+    column_data_type3->set_isarray(false);
     column3->set_isnotnull(true);
     column3->set_allowcommittimestamp(true);
 
@@ -192,36 +192,36 @@ TEST(DDLStatementProtoToString, TableColumnsToStringTest) {
 }
 
 TEST(DDLStatementProtoToString, ColumnsToString) {
-    CreateTable createTable;
+    CreateTable create_table;
 
-    EXPECT_EQ(createTable.primarykeys().size(), 0);
-    EXPECT_EQ(toString(createTable.primarykeys()), "");
+    EXPECT_EQ(create_table.primarykeys().size(), 0);
+    EXPECT_EQ(toString(create_table.primarykeys()), "");
 
-    Column* column1 = createTable.add_primarykeys();
+    Column* column1 = create_table.add_primarykeys();
     column1->set_columnname("testColumn1");
     
-    ColumnDataType* columnDataType1 = column1->mutable_columndatatype();
-    columnDataType1->set_scalartype(ColumnDataType::STRING);
-    columnDataType1->set_length(200);
-    columnDataType1->set_lengthtype(ColumnDataType::UNBOUND);
-    columnDataType1->set_isarray(false);
+    ColumnDataType* column_data_type1 = column1->mutable_columndatatype();
+    column_data_type1->set_scalartype(ColumnDataType::STRING);
+    column_data_type1->set_length(200);
+    column_data_type1->set_lengthtype(ColumnDataType::UNBOUND);
+    column_data_type1->set_isarray(false);
     column1->set_isnotnull(true);
     column1->set_allowcommittimestamp(true);
 
-    Column* column2 = createTable.add_primarykeys();
+    Column* column2 = create_table.add_primarykeys();
     column2->set_columnname("testColumn2");
     
-    ColumnDataType* columnDataType2 = column2->mutable_columndatatype();
-    columnDataType2->set_scalartype(ColumnDataType::BOOL);
-    columnDataType2->set_length(2);
-    columnDataType2->set_lengthtype(ColumnDataType::MAX);
-    columnDataType2->set_isarray(true);
+    ColumnDataType* column_data_type2 = column2->mutable_columndatatype();
+    column_data_type2->set_scalartype(ColumnDataType::BOOL);
+    column_data_type2->set_length(2);
+    column_data_type2->set_lengthtype(ColumnDataType::MAX);
+    column_data_type2->set_isarray(true);
     column2->set_isnotnull(false);
     column2->set_allowcommittimestamp(false);
 
-    EXPECT_EQ(createTable.primarykeys().size(), 2);
+    EXPECT_EQ(create_table.primarykeys().size(), 2);
 
-    EXPECT_EQ(toString(createTable.primarykeys()), 
+    EXPECT_EQ(toString(create_table.primarykeys()), 
         absl::StrCat("testColumn1 STRING( 200 ) NOT NULL ", 
         "OPTIONS ( allow_commit_timestamp = true ),",
         "testColumn2 ARRAY< BOOL >  OPTIONS",
@@ -232,17 +232,17 @@ TEST(DDLStatementProtoToString, ColumnToStringTest) {
     Column column;
     column.set_columnname("testColumn");
     
-    ColumnDataType* columnDataType = column.mutable_columndatatype();
+    ColumnDataType* column_data_type = column.mutable_columndatatype();
 
-    EXPECT_EQ(columnDataType->has_scalartype(), false);
-    EXPECT_EQ(columnDataType->has_length(), false);
-    EXPECT_EQ(columnDataType->has_lengthtype(), false);
-    EXPECT_EQ(columnDataType->has_isarray(), false);
+    EXPECT_EQ(column_data_type->has_scalartype(), false);
+    EXPECT_EQ(column_data_type->has_length(), false);
+    EXPECT_EQ(column_data_type->has_lengthtype(), false);
+    EXPECT_EQ(column_data_type->has_isarray(), false);
 
-    columnDataType->set_scalartype(ColumnDataType::STRING);
-    columnDataType->set_length(200);
-    columnDataType->set_lengthtype(ColumnDataType::BOUND);
-    columnDataType->set_isarray(false);
+    column_data_type->set_scalartype(ColumnDataType::STRING);
+    column_data_type->set_length(200);
+    column_data_type->set_lengthtype(ColumnDataType::BOUND);
+    column_data_type->set_isarray(false);
 
     column.set_isnotnull(true);
     column.set_allowcommittimestamp(true);
@@ -252,82 +252,82 @@ TEST(DDLStatementProtoToString, ColumnToStringTest) {
 }
 
 TEST(DDLStatementProtoToString, ColumnInfoDataToStringTest) {
-    ColumnDataType columnDataType;
+    ColumnDataType column_data_type;
 
-    EXPECT_EQ(columnDataType.has_scalartype(), false);
-    EXPECT_EQ(columnDataType.has_length(), false);
-    EXPECT_EQ(columnDataType.has_lengthtype(), false);
-    EXPECT_EQ(columnDataType.has_isarray(), false);
+    EXPECT_EQ(column_data_type.has_scalartype(), false);
+    EXPECT_EQ(column_data_type.has_length(), false);
+    EXPECT_EQ(column_data_type.has_lengthtype(), false);
+    EXPECT_EQ(column_data_type.has_isarray(), false);
 
-    columnDataType.set_scalartype(ColumnDataType::STRING);
-    columnDataType.set_length(200);
-    columnDataType.set_lengthtype(ColumnDataType::BOUND);
+    column_data_type.set_scalartype(ColumnDataType::STRING);
+    column_data_type.set_length(200);
+    column_data_type.set_lengthtype(ColumnDataType::BOUND);
 
-    columnDataType.set_isarray(false);
-    EXPECT_EQ(toString(columnDataType), "STRING( 201 )");  
+    column_data_type.set_isarray(false);
+    EXPECT_EQ(toString(column_data_type), "STRING( 201 )");  
 
-    columnDataType.set_isarray(true);
-    EXPECT_EQ(toString(columnDataType), "ARRAY< STRING( 201 ) >");  
+    column_data_type.set_isarray(true);
+    EXPECT_EQ(toString(column_data_type), "ARRAY< STRING( 201 ) >");  
 }
 
 TEST(DDLStatementProtoToString, ColumnDataTypeToStringHelperTest) {
-    ColumnDataType columnDataType;
+    ColumnDataType column_data_type;
 
-    EXPECT_EQ(columnDataType.has_scalartype(), false);
-    EXPECT_EQ(columnDataType.has_length(), false);
-    EXPECT_EQ(columnDataType.has_lengthtype(), false);
+    EXPECT_EQ(column_data_type.has_scalartype(), false);
+    EXPECT_EQ(column_data_type.has_length(), false);
+    EXPECT_EQ(column_data_type.has_lengthtype(), false);
 
-    columnDataType.set_scalartype(ColumnDataType::BOOL);
-    columnDataType.set_length(-500);
-    columnDataType.set_lengthtype(ColumnDataType::UNBOUND);
-    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
-        columnDataType.lengthtype()), "BOOL");
+    column_data_type.set_scalartype(ColumnDataType::BOOL);
+    column_data_type.set_length(-500);
+    column_data_type.set_lengthtype(ColumnDataType::UNBOUND);
+    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
+        column_data_type.lengthtype()), "BOOL");
 
-    columnDataType.set_scalartype(ColumnDataType::INT64);
-    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
-        columnDataType.lengthtype()), "INT64");
+    column_data_type.set_scalartype(ColumnDataType::INT64);
+    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
+        column_data_type.lengthtype()), "INT64");
     
-    columnDataType.set_scalartype(ColumnDataType::FLOAT64);
-    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
-        columnDataType.lengthtype()), "FLOAT64");
+    column_data_type.set_scalartype(ColumnDataType::FLOAT64);
+    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
+        column_data_type.lengthtype()), "FLOAT64");
 
-    columnDataType.set_scalartype(ColumnDataType::DATE);
-    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
-        columnDataType.lengthtype()), "DATE");
+    column_data_type.set_scalartype(ColumnDataType::DATE);
+    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
+        column_data_type.lengthtype()), "DATE");
 
-    columnDataType.set_scalartype(ColumnDataType::TIMESTAMP);
-    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
-        columnDataType.lengthtype()), "TIMESTAMP");
+    column_data_type.set_scalartype(ColumnDataType::TIMESTAMP);
+    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
+        column_data_type.lengthtype()), "TIMESTAMP");
 
-    columnDataType.set_scalartype(ColumnDataType::STRING);
-    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
-        columnDataType.lengthtype()), "STRING( -500 )");
-    columnDataType.set_lengthtype(ColumnDataType::MAX);
-    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
-        columnDataType.lengthtype()), "STRING( MAX )");
-    columnDataType.set_lengthtype(ColumnDataType::BOUND);
-    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
-        columnDataType.lengthtype()), "STRING( 501 )");
+    column_data_type.set_scalartype(ColumnDataType::STRING);
+    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
+        column_data_type.lengthtype()), "STRING( -500 )");
+    column_data_type.set_lengthtype(ColumnDataType::MAX);
+    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
+        column_data_type.lengthtype()), "STRING( MAX )");
+    column_data_type.set_lengthtype(ColumnDataType::BOUND);
+    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
+        column_data_type.lengthtype()), "STRING( 501 )");
     // test that the max wraps back to 1
-    columnDataType.set_length(2621440);
-    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
-        columnDataType.lengthtype()), "STRING( 1 )");
+    column_data_type.set_length(2621440);
+    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
+        column_data_type.lengthtype()), "STRING( 1 )");
 
-    columnDataType.set_length(-500);
-    columnDataType.set_lengthtype(ColumnDataType::UNBOUND);
-    columnDataType.set_scalartype(ColumnDataType::BYTES);
-    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
-        columnDataType.lengthtype()), "BYTES( -500 )");
-    columnDataType.set_lengthtype(ColumnDataType::MAX);
-    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
-        columnDataType.lengthtype()), "BYTES( MAX )");
-    columnDataType.set_lengthtype(ColumnDataType::BOUND);
-    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
-        columnDataType.lengthtype()), "BYTES( 501 )");
+    column_data_type.set_length(-500);
+    column_data_type.set_lengthtype(ColumnDataType::UNBOUND);
+    column_data_type.set_scalartype(ColumnDataType::BYTES);
+    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
+        column_data_type.lengthtype()), "BYTES( -500 )");
+    column_data_type.set_lengthtype(ColumnDataType::MAX);
+    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
+        column_data_type.lengthtype()), "BYTES( MAX )");
+    column_data_type.set_lengthtype(ColumnDataType::BOUND);
+    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
+        column_data_type.lengthtype()), "BYTES( 501 )");
     // test that the max wraps back to 1
-    columnDataType.set_length(10485760);
-    EXPECT_EQ(toString(columnDataType.scalartype(), columnDataType.length(), 
-        columnDataType.lengthtype()), "BYTES( 1 )");
+    column_data_type.set_length(10485760);
+    EXPECT_EQ(toString(column_data_type.scalartype(), column_data_type.length(), 
+        column_data_type.lengthtype()), "BYTES( 1 )");
 }
 
 TEST(DDLStatementProtoToString, IsColumnNotNullToStringTest) {
@@ -341,25 +341,25 @@ TEST(DDLStatementProtoToString, ColumnOptionsToStringTest) {
 }
 
 TEST(DDLStatementProtoToString, ToPrimaryKeysTest) {
-    CreateTable createTable;
+    CreateTable create_table;
 
-    Column* column1 = createTable.add_primarykeys();
+    Column* column1 = create_table.add_primarykeys();
     EXPECT_EQ(column1->has_columnname(), false);
     EXPECT_EQ(column1->has_orientation(), false);
 
     column1->set_orientation(Column::ASC);
     column1->set_columnname("testColumn1");
 
-    Column* column2 = createTable.add_primarykeys();
+    Column* column2 = create_table.add_primarykeys();
     EXPECT_EQ(column2->has_columnname(), false);
     EXPECT_EQ(column2->has_orientation(), false);
 
     column2->set_orientation(Column::DESC);
     column2->set_columnname("testColumn2");
 
-    EXPECT_EQ(createTable.primarykeys().size(), 2);
+    EXPECT_EQ(create_table.primarykeys().size(), 2);
 
-    EXPECT_EQ(toPrimaryKeys(createTable.primarykeys()), "testColumn1 ASC,testColumn2 DESC");
+    EXPECT_EQ(toPrimaryKeys(create_table.primarykeys()), "testColumn1 ASC,testColumn2 DESC");
 }
 
 TEST(DDLStatementProtoToString, ColumnToPrimaryKeyTest) {

--- a/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
+++ b/src/fuzz/spanner_emulator_ddl_statement_proto_to_string_test.cc
@@ -1,0 +1,349 @@
+//
+// Copyright 2020 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include <string>
+
+#include "src/fuzz/protobufs/create_table.pb.h"
+#include "src/fuzz/protobufs/spanner_ddl.pb.h"
+#include "src/fuzz/protobufs/utils/spanner_emulator_ddl_statement_proto_to_string.h"
+#include "gtest/gtest.h"
+#include <google/protobuf/repeated_field.h>
+
+#include "absl/strings/substitute.h"
+#include "absl/strings/str_cat.h"
+
+using spanner_ddl::SpannerFuzzingStatements;
+using spanner_ddl::SpannerDDLStatement;
+using spanner_ddl::CreateTable;
+using spanner_ddl::Column;
+using spanner_ddl::ColumnDataInfo;
+
+//TODO: add more to this test as more APIs are added
+TEST(DDLStatementProtoToString, DDLStatementToString) {
+    SpannerFuzzingStatements statements;
+    SpannerDDLStatement* statement1 = statements.add_statements();
+
+    CreateTable* createTable = statement1->mutable_createtable();
+    createTable->set_tablename("testTable");
+
+    Column* column1 = createTable->add_primarykeys();
+    column1->set_columnname("testColumn1");
+    
+    ColumnDataInfo* columnDataInfo1 = column1->mutable_columndatainfo();
+    columnDataInfo1->set_scalartype(ColumnDataInfo::STRING);
+    columnDataInfo1->set_length(200);
+    columnDataInfo1->set_lengthtype(ColumnDataInfo::UNBOUND);
+    columnDataInfo1->set_isarray(false);
+    column1->set_isnotnull(true);
+    column1->set_allowcommittimestamp(true);
+    column1->set_orientation(Column::ASC);
+
+    Column* column2 = createTable->add_primarykeys();
+    column2->set_columnname("testColumn2");
+    
+    ColumnDataInfo* columnDataInfo2 = column2->mutable_columndatainfo();
+    columnDataInfo2->set_scalartype(ColumnDataInfo::BOOL);
+    columnDataInfo2->set_length(2);
+    columnDataInfo2->set_lengthtype(ColumnDataInfo::MAX);
+    columnDataInfo2->set_isarray(true);
+    column2->set_isnotnull(false);
+    column2->set_allowcommittimestamp(false);
+    column2->set_orientation(Column::DESC);
+
+    Column* column3 = createTable->add_nonprimarykeys();
+    column3->set_columnname("testColumn3");
+
+    ColumnDataInfo* columnDataInfo3 = column3->mutable_columndatainfo();
+    columnDataInfo3->set_scalartype(ColumnDataInfo::TIMESTAMP);
+    columnDataInfo3->set_length(-100);
+    columnDataInfo3->set_lengthtype(ColumnDataInfo::BOUND);
+    columnDataInfo3->set_isarray(false);
+    column3->set_isnotnull(false);
+    column3->set_allowcommittimestamp(true);
+
+    EXPECT_EQ(createTable->primarykeys().size(), 2);
+    EXPECT_EQ(createTable->nonprimarykeys().size(), 1);
+
+    EXPECT_EQ(toString(*statement1), 
+        absl::StrCat("CREATE TABLE testTable ([ { testColumn1 STRING( 200 )",
+        " NOT NULL { OPTIONS ( allow_commit_timestamp = { true } ) } },",
+        "{ testColumn2 ARRAY< BOOL >  { OPTIONS ( allow_commit_timestamp = ",
+        "{ null } ) } },{ testColumn3 TIMESTAMP  { OPTIONS ( ",
+        "allow_commit_timestamp = { true } ) } } ]) PRIMARY KEY ( ",
+        "[testColumn1 [ { ASC } ],testColumn2 [ { DESC } ]] )"));
+}
+
+TEST(DDLStatementProtoToString, CreateTableToString) {
+    CreateTable createTable;
+    createTable.set_tablename("testTable");
+
+    Column* column1 = createTable.add_primarykeys();
+    column1->set_columnname("testColumn1");
+    
+    ColumnDataInfo* columnDataInfo1 = column1->mutable_columndatainfo();
+    columnDataInfo1->set_scalartype(ColumnDataInfo::STRING);
+    columnDataInfo1->set_length(200);
+    columnDataInfo1->set_lengthtype(ColumnDataInfo::UNBOUND);
+    columnDataInfo1->set_isarray(false);
+    column1->set_isnotnull(true);
+    column1->set_allowcommittimestamp(true);
+    column1->set_orientation(Column::ASC);
+
+    Column* column2 = createTable.add_primarykeys();
+    column2->set_columnname("testColumn2");
+    
+    ColumnDataInfo* columnDataInfo2 = column2->mutable_columndatainfo();
+    columnDataInfo2->set_scalartype(ColumnDataInfo::BOOL);
+    columnDataInfo2->set_length(2);
+    columnDataInfo2->set_lengthtype(ColumnDataInfo::MAX);
+    columnDataInfo2->set_isarray(true);
+    column2->set_isnotnull(false);
+    column2->set_allowcommittimestamp(false);
+    column2->set_orientation(Column::DESC);
+
+    Column* column3 = createTable.add_nonprimarykeys();
+    column3->set_columnname("testColumn3");
+
+    ColumnDataInfo* columnDataInfo3 = column3->mutable_columndatainfo();
+    columnDataInfo3->set_scalartype(ColumnDataInfo::TIMESTAMP);
+    columnDataInfo3->set_length(-100);
+    columnDataInfo3->set_lengthtype(ColumnDataInfo::BOUND);
+    columnDataInfo3->set_isarray(false);
+    column3->set_isnotnull(false);
+    column3->set_allowcommittimestamp(true);
+
+    EXPECT_EQ(createTable.primarykeys().size(), 2);
+    EXPECT_EQ(createTable.nonprimarykeys().size(), 1);
+
+
+    EXPECT_EQ(toString(createTable), 
+        absl::StrCat("CREATE TABLE testTable ([ { testColumn1 STRING( ",
+        "200 ) NOT NULL { OPTIONS ( allow_commit_timestamp = { true } )",
+        " } },{ testColumn2 ARRAY< BOOL >  { OPTIONS ( allow_commit_timestamp",
+        " = { null } ) } },{ testColumn3 TIMESTAMP  { OPTIONS ( ",
+        "allow_commit_timestamp = { true } ) } } ]) PRIMARY KEY ( ",
+        "[testColumn1 [ { ASC } ],testColumn2 [ { DESC } ]] )"));
+}
+
+TEST(DDLStatementProtoToString, ColumnsToString) {
+    CreateTable createTable;
+
+    Column* column1 = createTable.add_primarykeys();
+    column1->set_columnname("testColumn1");
+    
+    ColumnDataInfo* columnDataInfo1 = column1->mutable_columndatainfo();
+    columnDataInfo1->set_scalartype(ColumnDataInfo::STRING);
+    columnDataInfo1->set_length(200);
+    columnDataInfo1->set_lengthtype(ColumnDataInfo::UNBOUND);
+    columnDataInfo1->set_isarray(false);
+    column1->set_isnotnull(true);
+    column1->set_allowcommittimestamp(true);
+
+    Column* column2 = createTable.add_primarykeys();
+    column2->set_columnname("testColumn2");
+    
+    ColumnDataInfo* columnDataInfo2 = column2->mutable_columndatainfo();
+    columnDataInfo2->set_scalartype(ColumnDataInfo::BOOL);
+    columnDataInfo2->set_length(2);
+    columnDataInfo2->set_lengthtype(ColumnDataInfo::MAX);
+    columnDataInfo2->set_isarray(true);
+    column2->set_isnotnull(false);
+    column2->set_allowcommittimestamp(false);
+
+    EXPECT_EQ(createTable.primarykeys().size(), 2);
+
+    EXPECT_EQ(toString(createTable.primarykeys()), 
+        absl::StrCat("{ testColumn1 STRING( 200 ) NOT NULL ", 
+        "{ OPTIONS ( allow_commit_timestamp = { true } ) } },",
+        "{ testColumn2 ARRAY< BOOL >  { OPTIONS (",
+        " allow_commit_timestamp = { null } ) } }"));
+}
+
+TEST(DDLStatementProtoToString, ColumnToStringTest) {
+    Column column;
+    column.set_columnname("testColumn");
+    
+    ColumnDataInfo* columnDataInfo = column.mutable_columndatainfo();
+
+    EXPECT_EQ(columnDataInfo->has_scalartype(), false);
+    EXPECT_EQ(columnDataInfo->has_length(), false);
+    EXPECT_EQ(columnDataInfo->has_lengthtype(), false);
+    EXPECT_EQ(columnDataInfo->has_isarray(), false);
+
+    columnDataInfo->set_scalartype(ColumnDataInfo::STRING);
+    columnDataInfo->set_length(200);
+    columnDataInfo->set_lengthtype(ColumnDataInfo::BOUND);
+    columnDataInfo->set_isarray(false);
+
+    column.set_isnotnull(true);
+    column.set_allowcommittimestamp(true);
+
+    EXPECT_EQ(toString(column), absl::StrCat("{ testColumn STRING( 201 )",
+    " NOT NULL { OPTIONS ( allow_commit_timestamp = { true } ) } },"));
+
+}
+
+TEST(DDLStatementProtoToString, ColumnInfoDataToStringTest) {
+    ColumnDataInfo columnDataInfo;
+
+    EXPECT_EQ(columnDataInfo.has_scalartype(), false);
+    EXPECT_EQ(columnDataInfo.has_length(), false);
+    EXPECT_EQ(columnDataInfo.has_lengthtype(), false);
+    EXPECT_EQ(columnDataInfo.has_isarray(), false);
+
+    columnDataInfo.set_scalartype(ColumnDataInfo::STRING);
+    columnDataInfo.set_length(200);
+    columnDataInfo.set_lengthtype(ColumnDataInfo::BOUND);
+
+    columnDataInfo.set_isarray(false);
+    EXPECT_EQ(toString(columnDataInfo), "STRING( 201 )");  
+
+    columnDataInfo.set_isarray(true);
+    EXPECT_EQ(toString(columnDataInfo), "ARRAY< STRING( 201 ) >");  
+
+}
+
+TEST(DDLStatementProtoToString, ColumnDataInfoToStringHelperTest) {
+    ColumnDataInfo columnDataInfo;
+
+    EXPECT_EQ(columnDataInfo.has_scalartype(), false);
+    EXPECT_EQ(columnDataInfo.has_length(), false);
+    EXPECT_EQ(columnDataInfo.has_lengthtype(), false);
+
+    columnDataInfo.set_scalartype(ColumnDataInfo::BOOL);
+    columnDataInfo.set_length(-500);
+    columnDataInfo.set_lengthtype(ColumnDataInfo::UNBOUND);
+    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
+        columnDataInfo.lengthtype()), "BOOL");
+
+    columnDataInfo.set_scalartype(ColumnDataInfo::INT64);
+    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
+        columnDataInfo.lengthtype()), "INT64");
+    
+    columnDataInfo.set_scalartype(ColumnDataInfo::FLOAT64);
+    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
+        columnDataInfo.lengthtype()), "FLOAT64");
+
+    columnDataInfo.set_scalartype(ColumnDataInfo::DATE);
+    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
+        columnDataInfo.lengthtype()), "DATE");
+
+    columnDataInfo.set_scalartype(ColumnDataInfo::TIMESTAMP);
+    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
+        columnDataInfo.lengthtype()), "TIMESTAMP");
+
+    columnDataInfo.set_scalartype(ColumnDataInfo::STRING);
+    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
+        columnDataInfo.lengthtype()), "STRING( -500 )");
+    columnDataInfo.set_lengthtype(ColumnDataInfo::MAX);
+    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
+        columnDataInfo.lengthtype()), "STRING( MAX )");
+    columnDataInfo.set_lengthtype(ColumnDataInfo::BOUND);
+    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
+        columnDataInfo.lengthtype()), "STRING( 501 )");
+    // test that the max wraps back to 1
+    columnDataInfo.set_length(2621440);
+    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
+        columnDataInfo.lengthtype()), "STRING( 1 )");
+
+    columnDataInfo.set_length(-500);
+    columnDataInfo.set_lengthtype(ColumnDataInfo::UNBOUND);
+    columnDataInfo.set_scalartype(ColumnDataInfo::BYTES);
+    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
+        columnDataInfo.lengthtype()), "BYTES( -500 )");
+    columnDataInfo.set_lengthtype(ColumnDataInfo::MAX);
+    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
+        columnDataInfo.lengthtype()), "BYTES( MAX )");
+    columnDataInfo.set_lengthtype(ColumnDataInfo::BOUND);
+    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
+        columnDataInfo.lengthtype()), "BYTES( 501 )");
+    // test that the max wraps back to 1
+    columnDataInfo.set_length(10485760);
+    EXPECT_EQ(toString(columnDataInfo.scalartype(), columnDataInfo.length(), 
+        columnDataInfo.lengthtype()), "BYTES( 1 )");
+}
+
+TEST(DDLStatementProtoToString, IsColumnNotNullToStringTest) {
+    EXPECT_EQ(isColumnNotNullToString(true), "NOT NULL");
+    EXPECT_EQ(isColumnNotNullToString(false), "");
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+TEST(DDLStatementProtoToString, ColumnOrientationTest) {
+    Column column;
+    EXPECT_EQ(column.has_orientation(), false);
+
+    column.set_orientation(Column::ASC);
+    EXPECT_EQ(toString(column.orientation()), "ASC");
+
+    column.set_orientation(Column::DESC);
+    EXPECT_EQ(toString(column.orientation()), "DESC");
+}
+
+TEST(DDLStatementProtoToString, ColumnToPrimaryKeyTest) {
+    Column column;
+    EXPECT_EQ(column.has_columnname(), false);
+    EXPECT_EQ(column.has_orientation(), false);
+
+    column.set_orientation(Column::ASC);
+    column.set_columnname("testName");
+
+    EXPECT_EQ(columnToPrimaryKey(column), "testName [ { ASC } ],");
+}
+
+TEST(DDLStatementProtoToString, ToPrimaryKeysTest) {
+    CreateTable createTable;
+
+    Column* column1 = createTable.add_primarykeys();
+    EXPECT_EQ(column1->has_columnname(), false);
+    EXPECT_EQ(column1->has_orientation(), false);
+
+    column1->set_orientation(Column::ASC);
+    column1->set_columnname("testName1");
+
+    Column* column2 = createTable.add_primarykeys();
+    EXPECT_EQ(column2->has_columnname(), false);
+    EXPECT_EQ(column2->has_orientation(), false);
+
+    column2->set_orientation(Column::DESC);
+    column2->set_columnname("testName2");
+
+    EXPECT_EQ(createTable.primarykeys().size(), 2);
+
+    EXPECT_EQ(toPrimaryKeys(createTable.primarykeys()), "testName1 [ { ASC } ],testName2 [ { DESC } ]");
+}
+
+TEST(DDLStatementProtoToString, ColumnOptionsToStringTest) {
+    EXPECT_EQ(columnOptionsToString(false), "{ OPTIONS ( allow_commit_timestamp = { null } ) }");
+    EXPECT_EQ(columnOptionsToString(true), "{ OPTIONS ( allow_commit_timestamp = { true } ) }");
+}
+
+
+
+

--- a/third_party/envoy/LICENSE
+++ b/third_party/envoy/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner].
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/envoy/README.md
+++ b/third_party/envoy/README.md
@@ -1,0 +1,9 @@
+## Envoy
+
+Code contained in this directory was inspired or excerpted from 
+[Envoy Proxy](https://github.com/envoyproxy/envoy). Please refer
+to the Envoy offical page for documentation.
+
+## License
+
+[Apache License 2.0](LICENSE)

--- a/third_party/envoy/libprotobuf_mutator.BUILD
+++ b/third_party/envoy/libprotobuf_mutator.BUILD
@@ -1,0 +1,20 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+licenses(["notice"])  # Apache 2
+
+cc_library(
+    name = "libprotobuf_mutator",
+    srcs = glob(
+        [
+            "src/**/*.cc",
+            "src/**/*.h",
+            "port/protobuf.h",
+        ],
+        exclude = ["**/*_test.cc"],
+    ),
+    hdrs = ["src/libfuzzer/libfuzzer_macro.h"],
+    include_prefix = "libprotobuf_mutator",
+    includes = ["."],
+    visibility = ["//visibility:public"],
+    deps = ["@com_google_protobuf//:protobuf"],
+) 


### PR DESCRIPTION
Changes include protocol buffers representing the create table API, changes to integrate protobufs/libprotobuf-mutator with the project, tests for converting protobufs to syntactically valid strings for the emulator, and the structured fuzz test itself.