### PR TITLE
Fixing a build break

### DIFF
--- a/src/fuzz/create_table_fuzz_test.cc
+++ b/src/fuzz/create_table_fuzz_test.cc
@@ -96,9 +96,8 @@ DEFINE_PROTO_FUZZER(const CreateTable& createTable) {
         if (!db_or) throw std::runtime_error(db_or.status().message());
 
     } catch (std::exception const& ex) {
-        LOG(ERROR) << "Failed to create table with the following DDL statement:";
-        LOG(ERROR) << createTableDDLStatement;
-        return 1;
+        LOG(INFO) << "Failed to create table with the following DDL statement:";
+        LOG(INFO) << createTableDDLStatement;
     }
     
     LOG(INFO) << "Created database [" << database << "]";


### PR DESCRIPTION
Fuzz test should not return 1 on an error, as this will happen some of the time.  Instead we should log the error and continue.